### PR TITLE
chore!: added provider name and icon url to config

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,7 @@ export interface AddFiatAccountParams {
 export interface FiatConnectClientConfig {
   baseUrl: string
   providerName: string
+  iconUrl: string
 }
 
 export interface ErrorResponse {

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,7 @@ export interface AddFiatAccountParams {
 
 export interface FiatConnectClientConfig {
   baseUrl: string
+  providerName: string
 }
 
 export interface ErrorResponse {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -27,7 +27,8 @@ const mockJwt =
 describe('FiatConnect SDK', () => {
   const client = new FiatConnectClient({
     baseUrl: 'https://fiat-connect-api.com',
-    providerName: 'Example Provider'
+    providerName: 'Example Provider',
+    iconUrl: 'https://storage.googleapis.com/celo-mobile-mainnet.appspot.com/images/valora-icon.png'
   })
 
   beforeEach(() => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -25,12 +25,13 @@ const mockJwt =
   'eyJhbGciOiJSUzI1NiIsInByb3BYIjo1MTk5OX0.eyJpc3MiOiJEaW5vQ2hpZXNhLmdpdGh1Yi5pbyIsInN1YiI6ImFubmEiLCJhdWQiOiJtaW5nIiwiaWF0IjoxNjQ3NTQ1OTk2LCJleHAiOjE2NDc1NDY1OTYsInByb3BZIjp7ImNsYXNzaWQiOiJ6azQyMW9pY3hndzlnNzZ4dHNjenQiLCJlbnRpdGxlbWVudCI6ZmFsc2V9fQ.V3E9CaxU632TrZ8pIuXFtOzS2xj2yy0LWEuc0HI5yMjcymmFCkMhNYBkXt60dRkkioSo0xvQa78ja8CXeB7ixBqxcpFRIxK6vRd6MZuKyGcp9EdwJSaJa_DVZ-a19qofuxUOQYDFbB--yZ0-2TQbQyJR35W0puEVBPYJUjKCvu8frtsr1c8mHQ9baRJEJtnQhI_hz4loUUr9rTvrtbex_7OyOldaTnejozAb92iLSITriFz1Rg8lo7sBCqITM4HorFGujgEw_xWT94tZTlXtR83KhZFZoFXA6WhBDXPwgotn0hiPYpF-D3DIJSJqCxw14tD50XpjT_JwqkfwrVQuTg'
 
 describe('FiatConnect SDK', () => {
-  const exampleIconUrl = 'https://storage.googleapis.com/celo-mobile-mainnet.appspot.com/images/valora-icon.png';
-  const exampleProviderName = 'Example Provider';
+  const exampleIconUrl =
+    'https://storage.googleapis.com/celo-mobile-mainnet.appspot.com/images/valora-icon.png'
+  const exampleProviderName = 'Example Provider'
   const client = new FiatConnectClient({
     baseUrl: 'https://fiat-connect-api.com',
     providerName: exampleProviderName,
-    iconUrl: exampleIconUrl
+    iconUrl: exampleIconUrl,
   })
 
   beforeEach(() => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -27,11 +27,15 @@ const mockJwt =
 describe('FiatConnect SDK', () => {
   const client = new FiatConnectClient({
     baseUrl: 'https://fiat-connect-api.com',
+    providerName: 'Example Provider'
   })
 
   beforeEach(() => {
     fetchMock.resetMocks()
     jest.clearAllMocks()
+  })
+  it('Provider name can be accessed', () => {
+    expect(client.config.providerName).toEqual('Example Provider')
   })
   describe('getQuoteIn', () => {
     it('calls /quote/in and returns QuoteResponse', async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -25,18 +25,21 @@ const mockJwt =
   'eyJhbGciOiJSUzI1NiIsInByb3BYIjo1MTk5OX0.eyJpc3MiOiJEaW5vQ2hpZXNhLmdpdGh1Yi5pbyIsInN1YiI6ImFubmEiLCJhdWQiOiJtaW5nIiwiaWF0IjoxNjQ3NTQ1OTk2LCJleHAiOjE2NDc1NDY1OTYsInByb3BZIjp7ImNsYXNzaWQiOiJ6azQyMW9pY3hndzlnNzZ4dHNjenQiLCJlbnRpdGxlbWVudCI6ZmFsc2V9fQ.V3E9CaxU632TrZ8pIuXFtOzS2xj2yy0LWEuc0HI5yMjcymmFCkMhNYBkXt60dRkkioSo0xvQa78ja8CXeB7ixBqxcpFRIxK6vRd6MZuKyGcp9EdwJSaJa_DVZ-a19qofuxUOQYDFbB--yZ0-2TQbQyJR35W0puEVBPYJUjKCvu8frtsr1c8mHQ9baRJEJtnQhI_hz4loUUr9rTvrtbex_7OyOldaTnejozAb92iLSITriFz1Rg8lo7sBCqITM4HorFGujgEw_xWT94tZTlXtR83KhZFZoFXA6WhBDXPwgotn0hiPYpF-D3DIJSJqCxw14tD50XpjT_JwqkfwrVQuTg'
 
 describe('FiatConnect SDK', () => {
+  const exampleIconUrl = 'https://storage.googleapis.com/celo-mobile-mainnet.appspot.com/images/valora-icon.png';
+  const exampleProviderName = 'Example Provider';
   const client = new FiatConnectClient({
     baseUrl: 'https://fiat-connect-api.com',
-    providerName: 'Example Provider',
-    iconUrl: 'https://storage.googleapis.com/celo-mobile-mainnet.appspot.com/images/valora-icon.png'
+    providerName: exampleProviderName,
+    iconUrl: exampleIconUrl
   })
 
   beforeEach(() => {
     fetchMock.resetMocks()
     jest.clearAllMocks()
   })
-  it('Provider name can be accessed', () => {
-    expect(client.config.providerName).toEqual('Example Provider')
+  it('Provider name and icon can be accessed', () => {
+    expect(client.config.providerName).toEqual(exampleProviderName)
+    expect(client.config.iconUrl).toEqual(exampleIconUrl)
   })
   describe('getQuoteIn', () => {
     it('calls /quote/in and returns QuoteResponse', async () => {


### PR DESCRIPTION
As a wallet this will be handy for displaying the provider in a list of options.

BREAKING CHANGE: added name, icon as required params for creating a FiatConnectClient instance

cc https://app.zenhub.com/workspaces/acquisition-squad-sprint-board-6010683afabec1001a090887/issues/valora-inc/wallet/1979