### PR TITLE
chore!: updated types

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@fiatconnect/fiatconnect-types": "^2.1.1",
+    "@fiatconnect/fiatconnect-types": "^3.0.0",
     "node-fetch": "^2.6.6",
     "ts-results": "^3.3.0"
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import {
+  AccountNumber,
   AddFiatAccountResponse,
   DeleteFiatAccountRequestParams,
   FiatAccountSchema,
@@ -7,7 +8,6 @@ import {
   KycRequestParams,
   KycSchema,
   KycStatusResponse,
-  MockCheckingAccount,
   PersonalDataAndDocumentsKyc,
   QuoteErrorResponse,
   QuoteRequestQuery,
@@ -67,7 +67,7 @@ export interface FiatConectApiClient {
 
 // These must be manually updated as more KYC and FiatAccount types become standardized
 export type KycSchemaData = PersonalDataAndDocumentsKyc // in the future this will be the union of all KYC schema types (currently there is just one)
-export type FiatAccountSchemaData = MockCheckingAccount // similarly, this will be the union of all fiat account schema types
+export type FiatAccountSchemaData = AccountNumber // similarly, this will be the union of all fiat account schema types
 
 export interface AddKycParams {
   kycSchemaName: KycSchema

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -267,13 +267,13 @@ describe('FiatConnect SDK', () => {
       fetchMock.mockResponseOnce(JSON.stringify(mockAddFiatAccountResponse))
       const response = await client.addFiatAccount(
         {
-          fiatAccountSchemaName: FiatAccountSchema.MockCheckingAccount,
+          fiatAccountSchemaName: FiatAccountSchema.AccountNumber,
           data: mockFiatAccountSchemaData,
         },
         mockJwt,
       )
       expect(fetchMock).toHaveBeenCalledWith(
-        'https://fiat-connect-api.com/accounts/MockCheckingAccount',
+        'https://fiat-connect-api.com/accounts/AccountNumber',
         expect.objectContaining({
           method: 'POST',
           headers: expect.objectContaining({
@@ -291,7 +291,7 @@ describe('FiatConnect SDK', () => {
       })
       const response = await client.addFiatAccount(
         {
-          fiatAccountSchemaName: FiatAccountSchema.MockCheckingAccount,
+          fiatAccountSchemaName: FiatAccountSchema.AccountNumber,
           data: mockFiatAccountSchemaData,
         },
         mockJwt,
@@ -303,7 +303,7 @@ describe('FiatConnect SDK', () => {
       fetchMock.mockRejectOnce(new Error('fake error message'))
       const response = await client.addFiatAccount(
         {
-          fiatAccountSchemaName: FiatAccountSchema.MockCheckingAccount,
+          fiatAccountSchemaName: FiatAccountSchema.AccountNumber,
           data: mockFiatAccountSchemaData,
         },
         mockJwt,

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -38,14 +38,23 @@ export const mockQuoteResponse: QuoteResponse = {
     cryptoType: CryptoType.cUSD,
     fiatAmount: '1.0',
     cryptoAmount: '1.0',
+    quoteId: 'mock_quote_id',
+    guaranteedUntil: '2030-01-01T00:00:00.000Z',
   },
   kyc: {
     kycRequired: true,
-    kycSchemas: [KycSchema.PersonalDataAndDocuments],
+    kycSchemas: [
+      { kycSchema: KycSchema.PersonalDataAndDocuments, allowedValues: {} },
+    ],
   },
   fiatAccount: {
-    [FiatAccountType.MockCheckingAccount]: {
-      fiatAccountSchemas: [FiatAccountSchema.MockCheckingAccount],
+    [FiatAccountType.BankAccount]: {
+      fiatAccountSchemas: [
+        {
+          fiatAccountSchema: FiatAccountSchema.AccountNumber,
+          allowedValues: {},
+        },
+      ],
       fee: '.001',
       feeType: FeeType.PlatformFee,
     },
@@ -91,13 +100,13 @@ export const mockFiatAccountSchemaData: FiatAccountSchemaData = {
 
 export const mockAddFiatAccountResponse: AddFiatAccountResponse = {
   fiatAccountId: '12345',
-  name: 'Checking Account',
-  institution: 'Chase',
-  fiatAccountType: FiatAccountType.MockCheckingAccount,
+  accountName: 'Checking Account',
+  institutionName: 'Chase',
+  fiatAccountType: FiatAccountType.BankAccount,
 }
 
 export const mockGetFiatAccountsResponse: GetFiatAccountsResponse = {
-  [FiatAccountSchema.MockCheckingAccount]: [mockAddFiatAccountResponse],
+  [FiatAccountType.BankAccount]: [mockAddFiatAccountResponse],
 }
 
 export const mockDeleteFiatAccountParams: DeleteFiatAccountRequestParams = {
@@ -111,6 +120,7 @@ export const mockTransferRequestParams: TransferRequestParams = {
     cryptoType: CryptoType.cUSD,
     amount: '5.0',
     fiatAccountId: '12358',
+    quoteId: 'mock_quote_id',
   },
 }
 

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -20,11 +20,7 @@ import {
   TransferStatusResponse,
   TransferType,
 } from '@fiatconnect/fiatconnect-types'
-import {
-  FiatAccountSchemaData,
-  KycSchemaData,
-  TransferRequestParams,
-} from '../src/types'
+import {FiatAccountSchemaData, KycSchemaData, TransferRequestParams,} from '../src/types'
 
 export const mockQuoteRequestQuery: QuoteRequestQuery = {
   fiatType: FiatType.USD,
@@ -91,11 +87,11 @@ export const mockKycStatusResponse: KycStatusResponse = {
 }
 
 export const mockFiatAccountSchemaData: FiatAccountSchemaData = {
-  bankName: 'Chase',
+  institutionName: 'Chase',
   accountName: 'Checking Account',
-  fiatType: FiatType.USD,
   accountNumber: '12533986',
-  routingNumber: '494187652',
+  country: 'US',
+  fiatAccountType: FiatAccountType.BankAccount
 }
 
 export const mockAddFiatAccountResponse: AddFiatAccountResponse = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -308,10 +308,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fiatconnect/fiatconnect-types@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@fiatconnect/fiatconnect-types/-/fiatconnect-types-2.1.1.tgz#fe7b63129703f87c7976208bd35b60aea71cf6ff"
-  integrity sha512-0UU0iMpddqH9VFcKdncrugWgmEo/IeyAV7hSGgC5wLOO7wmWRN2KdrnjFdvdu1ciUdyPyceGkaturMoRRTw/MQ==
+"@fiatconnect/fiatconnect-types@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@fiatconnect/fiatconnect-types/-/fiatconnect-types-3.0.0.tgz#684b8f5c6beefb98db3a2a3c41066b976e099269"
+  integrity sha512-JMyAgkHNufqbo9roDmUpzhZH3UMbhyuLYYMI9kE1qQTtQMPVlPz9zHbS2syFz2Ymdjl7wzgIijph+QckYwwP8A==
 
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"


### PR DESCRIPTION
BREAKING CHANGE: creating transfer now requires quoteId parameter

other changes:
- cREAL added as crypto currency
- guaranteedUntil field is now guaranteed on quote responses
- quoteId field is now guaranteed on quote responses
- added AccountNumber, removed MockCheckingAccount fiat account type