### PR TITLE
chore: version bump fiatconnect-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@fiatconnect/fiatconnect-types": "^3.0.0",
+    "@fiatconnect/fiatconnect-types": "^3.1.0",
     "node-fetch": "^2.6.6",
     "ts-results": "^3.3.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -308,7 +308,7 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fiatconnect/fiatconnect-types@^3.0.0":
+"@fiatconnect/fiatconnect-types@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@fiatconnect/fiatconnect-types/-/fiatconnect-types-3.1.0.tgz#092dbe1b43d020a4751a108a5af52ac6cd95f4a7"
   integrity sha512-Q7y3O/+tE9ewOYWlZvSVmSMQkLn25C1fSN7qiZAbKJaXJctZ2HvSrwYAHgL+eNirw6yj6+ursJCUsXTpnYydBA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -309,9 +309,9 @@
     strip-json-comments "^3.1.1"
 
 "@fiatconnect/fiatconnect-types@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@fiatconnect/fiatconnect-types/-/fiatconnect-types-3.0.0.tgz#684b8f5c6beefb98db3a2a3c41066b976e099269"
-  integrity sha512-JMyAgkHNufqbo9roDmUpzhZH3UMbhyuLYYMI9kE1qQTtQMPVlPz9zHbS2syFz2Ymdjl7wzgIijph+QckYwwP8A==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@fiatconnect/fiatconnect-types/-/fiatconnect-types-3.1.0.tgz#092dbe1b43d020a4751a108a5af52ac6cd95f4a7"
+  integrity sha512-Q7y3O/+tE9ewOYWlZvSVmSMQkLn25C1fSN7qiZAbKJaXJctZ2HvSrwYAHgL+eNirw6yj6+ursJCUsXTpnYydBA==
 
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"


### PR DESCRIPTION
accounts endpoints are already plural, and clock sync and auth are accounted for in other issues, so this is all we need for https://github.com/valora-inc/wallet/issues/2359