### PR TITLE
feat(clock): Add clock support to SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@fiatconnect/fiatconnect-types": "^3.1.0",
+    "@fiatconnect/fiatconnect-types": "^3.2.0",
     "node-fetch": "^2.6.6",
     "ts-results": "^3.3.0"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
 
     const t1 = new Date(clockResponse.val.time).getTime()
     // We can assume that t1 and t2 are sufficiently close to each other
-    return Ok((t1 - t0 + (t1 - t3)) / 2)
+    return Ok((t1 - t0 + t1 - t3) / 2)
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ import {
 import { Result } from 'ts-results'
 
 export interface FiatConectApiClient {
+  getClock(): Promise<>
   getQuoteIn(
     params: QuoteRequestQuery,
     jwt: string,
@@ -92,4 +93,9 @@ export interface ErrorResponse {
 export interface TransferRequestParams {
   idempotencyKey: string
   data: TransferRequestBody
+}
+
+// todo(jbergeron): Import this from the types repo
+export type ClockResponse = {
+  time: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,11 +16,12 @@ import {
   TransferResponse,
   TransferStatusRequestParams,
   TransferStatusResponse,
+  ClockResponse,
 } from '@fiatconnect/fiatconnect-types'
 import { Result } from 'ts-results'
 
 export interface FiatConectApiClient {
-  getClockDiff(): Promise<Result<number, ErrorResponse>>
+  getClockDiffApprox(): Promise<Result<ClockDiffResult, ErrorResponse>>
   getClock(): Promise<Result<ClockResponse, ErrorResponse>>
   getQuoteIn(
     params: QuoteRequestQuery,
@@ -96,7 +97,14 @@ export interface TransferRequestParams {
   data: TransferRequestBody
 }
 
-// todo(jbergeron): Import this from the types repo
-export type ClockResponse = {
-  time: string
+export interface ClockDiffParams {
+  t0: number
+  t1: number
+  t2: number
+  t3: number
+}
+
+export interface ClockDiffResult {
+  diff: number
+  maxError: number
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,8 @@ import {
 import { Result } from 'ts-results'
 
 export interface FiatConectApiClient {
-  getClock(): Promise<>
+  getClockDiff(): Promise<Result<number, ErrorResponse>>
+  getClock(): Promise<Result<ClockResponse, ErrorResponse>>
   getQuoteIn(
     params: QuoteRequestQuery,
     jwt: string,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -38,7 +38,6 @@ describe('FiatConnect SDK', () => {
   beforeEach(() => {
     fetchMock.resetMocks()
     jest.clearAllMocks()
-    jest.useRealTimers()
   })
   it('Provider name and icon can be accessed', () => {
     expect(client.config.providerName).toEqual(exampleProviderName)

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -20,7 +20,12 @@ import {
   TransferStatusResponse,
   TransferType,
 } from '@fiatconnect/fiatconnect-types'
-import {FiatAccountSchemaData, KycSchemaData, TransferRequestParams,} from '../src/types'
+import {
+  FiatAccountSchemaData,
+  KycSchemaData,
+  TransferRequestParams,
+  ClockResponse,
+} from '../src/types'
 
 export const mockQuoteRequestQuery: QuoteRequestQuery = {
   fiatType: FiatType.USD,
@@ -91,7 +96,7 @@ export const mockFiatAccountSchemaData: FiatAccountSchemaData = {
   accountName: 'Checking Account',
   accountNumber: '12533986',
   country: 'US',
-  fiatAccountType: FiatAccountType.BankAccount
+  fiatAccountType: FiatAccountType.BankAccount,
 }
 
 export const mockAddFiatAccountResponse: AddFiatAccountResponse = {
@@ -138,4 +143,8 @@ export const mockTransferStatusResponse: TransferStatusResponse = {
   amountProvided: '5.0',
   amountReceived: '5.0',
   fiatAccountId: '12358',
+}
+
+export const mockClockResponse: ClockResponse = {
+  time: '2022-05-02T22:06:00+0000',
 }

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -19,12 +19,12 @@ import {
   TransferStatusRequestParams,
   TransferStatusResponse,
   TransferType,
+  ClockResponse,
 } from '@fiatconnect/fiatconnect-types'
 import {
   FiatAccountSchemaData,
   KycSchemaData,
   TransferRequestParams,
-  ClockResponse,
 } from '../src/types'
 
 export const mockQuoteRequestQuery: QuoteRequestQuery = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -308,10 +308,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fiatconnect/fiatconnect-types@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@fiatconnect/fiatconnect-types/-/fiatconnect-types-3.1.0.tgz#092dbe1b43d020a4751a108a5af52ac6cd95f4a7"
-  integrity sha512-Q7y3O/+tE9ewOYWlZvSVmSMQkLn25C1fSN7qiZAbKJaXJctZ2HvSrwYAHgL+eNirw6yj6+ursJCUsXTpnYydBA==
+"@fiatconnect/fiatconnect-types@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@fiatconnect/fiatconnect-types/-/fiatconnect-types-3.2.0.tgz#36eb018d22160ab114ee842dd843a659bbc53213"
+  integrity sha512-OP4LJkEXPb+0WeUhO4iWf+X2EQuLWAGyWikRpyf74gLQZvPuV8hFN9TArCJYGqNuJHPvZ2VBOuzosTroSW5STg==
 
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"


### PR DESCRIPTION
Fixes [this](https://app.zenhub.com/workspaces/acquisition-squad-sprint-board-6010683afabec1001a090887/issues/valora-inc/in-house-liquidity/569) ZH issue.

Since calculating clock _offset_ seems like something that clients will want to do, I added in a tiny convenience method that implements a simple version of [this](https://en.wikipedia.org/wiki/Network_Time_Protocol#Clock_synchronization_algorithm) algorithm.
