### PR TITLE
feat(auth): update login to always create a session

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ const NETWORK_CHAIN_IDS = {
   [Network.Alfajores]: 44787,
   [Network.Mainnet]: 42220,
 }
+const SESSION_DURATION_MS = 14400000 // 4 hours
 
 const fetch = fetchCookie(nodeFetch)
 
@@ -50,6 +51,9 @@ export default class FiatConnectClient implements FiatConectApiClient {
   }
 
   async _ensureLogin() {
+    if (this._sessionExpiry && this._sessionExpiry > new Date()) {
+      return
+    }
     const loginResult = await this.login()
     if (!loginResult.ok) {
       throw new Error(`Login failed: ${loginResult.val.error}`)
@@ -64,10 +68,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
    */
   async login(): Promise<Result<'success', ErrorResponse>> {
     try {
-      if (this._sessionExpiry && this._sessionExpiry > new Date()) {
-        return Ok('success')
-      }
-      const expirationDate = new Date(Date.now() + 14400000) // 4 hours from now
+      const expirationDate = new Date(Date.now() + SESSION_DURATION_MS)
       const siweMessage = new SiweMessage({
         domain: new URL(this.config.baseUrl).hostname,
         address: this.config.accountAddress,


### PR DESCRIPTION
One problem with the existing login method is that there's no way for the client to enforce a session. This might be needed by clients if for example, a method returns Unauthorized because of an expired session, but the `FiatConnectClient` instance still has a future `sessionExpiry` (maybe due to a clock skew or providers issue a session < 4h). This updates the `login` method to always create a new session and moves the sessionExpiry check login to the `_ensureLogin` method.