### PR TITLE
feat(auth): add support for client API keys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -174,6 +174,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
     try {
       const response = await fetch(`${this.config.baseUrl}/clock`, {
         method: 'GET',
+        headers: this._getAuthHeader(),
       })
       const data = await response.json()
       if (!response.ok) {
@@ -296,6 +297,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            ...this._getAuthHeader(),
           },
           body: JSON.stringify(params.data),
         },
@@ -345,6 +347,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
         {
           method: 'DELETE',
           headers: this._getAuthHeader(),
+          ...this._getAuthHeader(),
         },
       )
       const data = await response.json()
@@ -370,6 +373,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
         headers: {
           'Content-Type': 'application/json',
           'Idempotency-Key': params.idempotencyKey,
+          ...this._getAuthHeader(),
         },
         body: JSON.stringify(params.data),
       })
@@ -396,6 +400,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
         headers: {
           'Content-Type': 'application/json',
           'Idempotency-Key': params.idempotencyKey,
+          ...this._getAuthHeader(),
         },
         body: JSON.stringify(params.data),
       })

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,12 @@ export default class FiatConnectClient implements FiatConectApiClient {
     this.signingFunction = signingFunction
   }
 
+  _getAuthHeader() {
+    if (this.config.apiKey) {
+      return {'Authorization': `Bearer ${this.config.apiKey}`}
+    }
+  }
+
   async _ensureLogin() {
     const loginResult = await this.login()
     if (!loginResult.ok) {
@@ -88,6 +94,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          ...this._getAuthHeader()
         },
         body: JSON.stringify(body),
       })
@@ -115,6 +122,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
         `${this.config.baseUrl}/quote/${inOrOut}?${queryParams}`,
         {
           method: 'GET',
+          headers: this._getAuthHeader(),
         },
       )
       const data = await response.json()
@@ -209,6 +217,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            ...this._getAuthHeader()
           },
           body: JSON.stringify(params.data),
         },
@@ -235,6 +244,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
         `${this.config.baseUrl}/kyc/${params.kycSchema}`,
         {
           method: 'DELETE',
+          headers: this._getAuthHeader()
         },
       )
       const data = await response.json()
@@ -259,6 +269,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
         `${this.config.baseUrl}/kyc/${params.kycSchema}`,
         {
           method: 'GET',
+          headers: this._getAuthHeader()
         },
       )
       const data = await response.json()
@@ -309,6 +320,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
       await this._ensureLogin()
       const response = await fetch(`${this.config.baseUrl}/accounts`, {
         method: 'GET',
+        headers: this._getAuthHeader()
       })
       const data = await response.json()
       if (!response.ok) {
@@ -332,6 +344,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
         `${this.config.baseUrl}/accounts/${params.fiatAccountId}`,
         {
           method: 'DELETE',
+          headers: this._getAuthHeader()
         },
       )
       const data = await response.json()
@@ -408,6 +421,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
         `${this.config.baseUrl}/transfer/${params.transferId}/status`,
         {
           method: 'GET',
+          headers: this._getAuthHeader()
         },
       )
       const data = await response.json()

--- a/src/index.ts
+++ b/src/index.ts
@@ -347,7 +347,6 @@ export default class FiatConnectClient implements FiatConectApiClient {
         {
           method: 'DELETE',
           headers: this._getAuthHeader(),
-          ...this._getAuthHeader(),
         },
       )
       const data = await response.json()

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
 
   _getAuthHeader() {
     if (this.config.apiKey) {
-      return {'Authorization': `Bearer ${this.config.apiKey}`}
+      return { Authorization: `Bearer ${this.config.apiKey}` }
     }
   }
 
@@ -94,7 +94,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          ...this._getAuthHeader()
+          ...this._getAuthHeader(),
         },
         body: JSON.stringify(body),
       })
@@ -217,7 +217,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            ...this._getAuthHeader()
+            ...this._getAuthHeader(),
           },
           body: JSON.stringify(params.data),
         },
@@ -244,7 +244,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
         `${this.config.baseUrl}/kyc/${params.kycSchema}`,
         {
           method: 'DELETE',
-          headers: this._getAuthHeader()
+          headers: this._getAuthHeader(),
         },
       )
       const data = await response.json()
@@ -269,7 +269,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
         `${this.config.baseUrl}/kyc/${params.kycSchema}`,
         {
           method: 'GET',
-          headers: this._getAuthHeader()
+          headers: this._getAuthHeader(),
         },
       )
       const data = await response.json()
@@ -320,7 +320,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
       await this._ensureLogin()
       const response = await fetch(`${this.config.baseUrl}/accounts`, {
         method: 'GET',
-        headers: this._getAuthHeader()
+        headers: this._getAuthHeader(),
       })
       const data = await response.json()
       if (!response.ok) {
@@ -344,7 +344,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
         `${this.config.baseUrl}/accounts/${params.fiatAccountId}`,
         {
           method: 'DELETE',
-          headers: this._getAuthHeader()
+          headers: this._getAuthHeader(),
         },
       )
       const data = await response.json()
@@ -421,7 +421,7 @@ export default class FiatConnectClient implements FiatConectApiClient {
         `${this.config.baseUrl}/transfer/${params.transferId}/status`,
         {
           method: 'GET',
-          headers: this._getAuthHeader()
+          headers: this._getAuthHeader(),
         },
       )
       const data = await response.json()

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,7 @@ export interface FiatConnectClientConfig {
   iconUrl: string
   network: Network
   accountAddress: string
+  apiKey?: string
 }
 
 export interface ErrorResponse {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -50,10 +50,12 @@ describe('FiatConnect SDK', () => {
     },
     signingFunction,
   )
+  const getHeadersMock = jest.spyOn(client, '_getAuthHeader')
 
   beforeEach(() => {
     jest.useFakeTimers().setSystemTime(new Date('2022-05-01T00:00:00Z'))
     fetchMock.resetMocks()
+    getHeadersMock.mockReset()
     jest.clearAllMocks()
     client._sessionExpiry = undefined
   })
@@ -69,10 +71,12 @@ describe('FiatConnect SDK', () => {
         'https://fiat-connect-api.com/clock',
         expect.objectContaining({
           method: 'GET',
+          headers: undefined,
         }),
       )
       expect(response.ok).toBeTruthy()
       expect(response.val).toMatchObject(mockClockResponse)
+      expect(getHeadersMock).toHaveBeenCalled()
     })
     it('handles fetch errors', async () => {
       fetchMock.mockRejectOnce(new Error('fake error message'))
@@ -273,16 +277,38 @@ describe('FiatConnect SDK', () => {
       }).rejects.toThrow('Login failed: invalid login')
     })
   })
+  describe('_getAuthHeader', () => {
+    it('returns auth header if client key is set', () => {
+      const clientWithApiKey = new FiatConnectClient(
+        {
+          baseUrl: 'https://fiat-connect-api.com',
+          providerName: exampleProviderName,
+          iconUrl: exampleIconUrl,
+          network: Network.Alfajores,
+          accountAddress,
+          apiKey: 'some-api-key',
+        },
+        signingFunction,
+      )
+      expect(clientWithApiKey._getAuthHeader()).toEqual({
+        Authorization: 'Bearer some-api-key',
+      })
+    })
+    it('returns undefined if client key is not set', () => {
+      expect(client._getAuthHeader()).toBeUndefined()
+    })
+  })
   describe('getQuoteIn', () => {
     it('calls /quote/in and returns QuoteResponse', async () => {
       fetchMock.mockResponseOnce(JSON.stringify(mockQuoteResponse))
       const response = await client.getQuoteIn(mockQuoteRequestQuery)
       expect(fetchMock).toHaveBeenCalledWith(
         'https://fiat-connect-api.com/quote/in?fiatType=USD&cryptoType=cUSD&country=DE',
-        expect.objectContaining({ method: 'GET' }),
+        expect.objectContaining({ method: 'GET', headers: undefined }),
       )
       expect(response.ok).toBeTruthy()
       expect(response.val).toMatchObject(mockQuoteResponse)
+      expect(getHeadersMock).toHaveBeenCalled()
     })
     it('handles API errors', async () => {
       fetchMock.mockResponseOnce(JSON.stringify(mockQuoteErrorResponse), {
@@ -309,10 +335,11 @@ describe('FiatConnect SDK', () => {
       const response = await client.getQuoteOut(mockQuoteRequestQuery)
       expect(fetchMock).toHaveBeenCalledWith(
         'https://fiat-connect-api.com/quote/out?fiatType=USD&cryptoType=cUSD&country=DE',
-        expect.objectContaining({ method: 'GET' }),
+        expect.objectContaining({ method: 'GET', headers: undefined }),
       )
       expect(response.ok).toBeTruthy()
       expect(response.val).toMatchObject(mockQuoteResponse)
+      expect(getHeadersMock).toHaveBeenCalled()
     })
     it('handles API errors', async () => {
       fetchMock.mockResponseOnce(JSON.stringify(mockQuoteErrorResponse), {
@@ -345,11 +372,37 @@ describe('FiatConnect SDK', () => {
       })
       expect(fetchMock).toHaveBeenCalledWith(
         'https://fiat-connect-api.com/kyc/PersonalDataAndDocuments',
-        expect.objectContaining({ method: 'POST' }),
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        }),
       )
       expect(response.ok).toBeTruthy()
       expect(response.val).toMatchObject(mockKycStatusResponse)
       expect(client._ensureLogin).toHaveBeenCalled()
+      expect(getHeadersMock).toHaveBeenCalled()
+    })
+    it('calls POST /kyc/${params.kycSchemaName} with auth header and returns KycStatusResponse', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockKycStatusResponse))
+      getHeadersMock.mockReturnValueOnce({ Authorization: 'Bearer api-key' })
+      const response = await client.addKyc({
+        kycSchemaName: KycSchema.PersonalDataAndDocuments,
+        data: mockKycSchemaData,
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://fiat-connect-api.com/kyc/PersonalDataAndDocuments',
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer api-key',
+          },
+        }),
+      )
+      expect(response.ok).toBeTruthy()
+      expect(response.val).toMatchObject(mockKycStatusResponse)
+      expect(client._ensureLogin).toHaveBeenCalled()
+      expect(getHeadersMock).toHaveBeenCalled()
     })
     it('handles API errors', async () => {
       const errorResponse = { error: FiatConnectError.ResourceExists }
@@ -391,6 +444,7 @@ describe('FiatConnect SDK', () => {
       expect(response.ok).toBeTruthy()
       expect(response.val).toBeUndefined()
       expect(client._ensureLogin).toHaveBeenCalled()
+      expect(getHeadersMock).toHaveBeenCalled()
     })
     it('handles API errors', async () => {
       const errorResponse = { error: FiatConnectError.ResourceNotFound }
@@ -425,11 +479,12 @@ describe('FiatConnect SDK', () => {
       })
       expect(fetchMock).toHaveBeenCalledWith(
         'https://fiat-connect-api.com/kyc/PersonalDataAndDocuments',
-        expect.objectContaining({ method: 'GET' }),
+        expect.objectContaining({ method: 'GET', headers: undefined }),
       )
       expect(response.ok).toBeTruthy()
       expect(response.val).toMatchObject(mockKycStatusResponse)
       expect(client._ensureLogin).toHaveBeenCalled()
+      expect(getHeadersMock).toHaveBeenCalled()
     })
     it('handles API errors', async () => {
       const errorResponse = { error: FiatConnectError.ResourceNotFound }
@@ -465,11 +520,37 @@ describe('FiatConnect SDK', () => {
       })
       expect(fetchMock).toHaveBeenCalledWith(
         'https://fiat-connect-api.com/accounts/AccountNumber',
-        expect.objectContaining({ method: 'POST' }),
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        }),
       )
       expect(response.ok).toBeTruthy()
       expect(response.val).toMatchObject(mockAddFiatAccountResponse)
       expect(client._ensureLogin).toHaveBeenCalled()
+      expect(getHeadersMock).toHaveBeenCalled()
+    })
+    it('calls POST /accounts/${params.fiatAccountSchemaName} and returns AddFiatAccountResponse', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockAddFiatAccountResponse))
+      getHeadersMock.mockReturnValueOnce({ Authorization: 'Bearer api-key' })
+      const response = await client.addFiatAccount({
+        fiatAccountSchemaName: FiatAccountSchema.AccountNumber,
+        data: mockFiatAccountSchemaData,
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://fiat-connect-api.com/accounts/AccountNumber',
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer api-key',
+          },
+        }),
+      )
+      expect(response.ok).toBeTruthy()
+      expect(response.val).toMatchObject(mockAddFiatAccountResponse)
+      expect(client._ensureLogin).toHaveBeenCalled()
+      expect(getHeadersMock).toHaveBeenCalled()
     })
     it('handles API errors', async () => {
       const errorResponse = { error: FiatConnectError.ResourceExists }
@@ -504,11 +585,12 @@ describe('FiatConnect SDK', () => {
       const response = await client.getFiatAccounts()
       expect(fetchMock).toHaveBeenCalledWith(
         'https://fiat-connect-api.com/accounts',
-        expect.objectContaining({ method: 'GET' }),
+        expect.objectContaining({ method: 'GET', headers: undefined }),
       )
       expect(response.ok).toBeTruthy()
       expect(response.val).toMatchObject(mockGetFiatAccountsResponse)
       expect(client._ensureLogin).toHaveBeenCalled()
+      expect(getHeadersMock).toHaveBeenCalled()
     })
     it('handles API errors', async () => {
       const errorResponse = { error: FiatConnectError.ResourceNotFound }
@@ -539,11 +621,12 @@ describe('FiatConnect SDK', () => {
       )
       expect(fetchMock).toHaveBeenCalledWith(
         'https://fiat-connect-api.com/accounts/12358',
-        expect.objectContaining({ method: 'DELETE' }),
+        expect.objectContaining({ method: 'DELETE', headers: undefined }),
       )
       expect(response.ok).toBeTruthy()
       expect(response.val).toBeUndefined()
       expect(client._ensureLogin).toHaveBeenCalled()
+      expect(getHeadersMock).toHaveBeenCalled()
     })
     it('handles API errors', async () => {
       const errorResponse = { error: FiatConnectError.ResourceNotFound }
@@ -586,6 +669,26 @@ describe('FiatConnect SDK', () => {
       expect(response.ok).toBeTruthy()
       expect(response.val).toMatchObject(mockTransferResponse)
       expect(client._ensureLogin).toHaveBeenCalled()
+      expect(getHeadersMock).toHaveBeenCalled()
+    })
+    it('calls POST /transfer/in with auth header and returns TransferResponse', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockTransferResponse))
+      getHeadersMock.mockReturnValueOnce({ Authorization: 'Bearer api-key' })
+      const response = await client.transferIn(mockTransferRequestParams)
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://fiat-connect-api.com/transfer/in',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Idempotency-Key': mockTransferRequestParams.idempotencyKey,
+            Authorization: 'Bearer api-key',
+          }),
+        }),
+      )
+      expect(response.ok).toBeTruthy()
+      expect(response.val).toMatchObject(mockTransferResponse)
+      expect(client._ensureLogin).toHaveBeenCalled()
+      expect(getHeadersMock).toHaveBeenCalled()
     })
     it('handles API errors', async () => {
       const errorResponse = { error: FiatConnectError.ResourceNotFound }
@@ -625,6 +728,26 @@ describe('FiatConnect SDK', () => {
       expect(response.ok).toBeTruthy()
       expect(response.val).toMatchObject(mockTransferResponse)
       expect(client._ensureLogin).toHaveBeenCalled()
+      expect(getHeadersMock).toHaveBeenCalled()
+    })
+    it('calls POST /transfer/out with auth header and returns TransferResponse', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockTransferResponse))
+      getHeadersMock.mockReturnValueOnce({ Authorization: 'Bearer api-key' })
+      const response = await client.transferOut(mockTransferRequestParams)
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://fiat-connect-api.com/transfer/out',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Idempotency-Key': mockTransferRequestParams.idempotencyKey,
+            Authorization: 'Bearer api-key',
+          }),
+        }),
+      )
+      expect(response.ok).toBeTruthy()
+      expect(response.val).toMatchObject(mockTransferResponse)
+      expect(client._ensureLogin).toHaveBeenCalled()
+      expect(getHeadersMock).toHaveBeenCalled()
     })
     it('handles API errors', async () => {
       const errorResponse = { error: FiatConnectError.ResourceNotFound }
@@ -656,11 +779,12 @@ describe('FiatConnect SDK', () => {
       )
       expect(fetchMock).toHaveBeenCalledWith(
         'https://fiat-connect-api.com/transfer/82938/status',
-        expect.objectContaining({ method: 'GET' }),
+        expect.objectContaining({ method: 'GET', headers: undefined }),
       )
       expect(response.ok).toBeTruthy()
       expect(response.val).toMatchObject(mockTransferStatusResponse)
       expect(client._ensureLogin).toHaveBeenCalled()
+      expect(getHeadersMock).toHaveBeenCalled()
     })
     it('handles API errors', async () => {
       const errorResponse = { error: FiatConnectError.ResourceNotFound }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -181,9 +181,11 @@ describe('FiatConnect SDK', () => {
       )
       expect(response.ok).toBeTruthy()
       expect(response.val).toEqual('success')
+      expect(getHeadersMock).toHaveBeenCalled()
     })
     it('returns error if login returns error response', async () => {
       jest.spyOn(siwe, 'generateNonce').mockReturnValueOnce('12345678')
+      getHeadersMock.mockReturnValueOnce({ Authorization: 'Bearer api-key' })
       fetchMock.mockResponseOnce('{"error": "InvalidParameters"}', {
         status: 400,
       })
@@ -204,7 +206,7 @@ describe('FiatConnect SDK', () => {
         'https://fiat-connect-api.com/auth/login',
         expect.objectContaining({
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', Authorization: 'Bearer api-key' },
           body: JSON.stringify({
             message: expectedSiweMessage.prepareMessage(),
             signature: 'signed message',
@@ -213,6 +215,7 @@ describe('FiatConnect SDK', () => {
       )
       expect(response.ok).toBeFalsy()
       expect(response.val).toEqual({ error: 'InvalidParameters' })
+      expect(getHeadersMock).toHaveBeenCalled()
     })
     it('returns error if login throws', async () => {
       signingFunction.mockRejectedValueOnce('sign error')
@@ -220,6 +223,7 @@ describe('FiatConnect SDK', () => {
 
       expect(response.ok).toBeFalsy()
       expect(response.val).toEqual({ error: 'sign error' })
+      expect(getHeadersMock).not.toHaveBeenCalled()
     })
   })
   describe('_ensureLogin', () => {


### PR DESCRIPTION
For [ZH issue](https://app.zenhub.com/workspaces/acquisition-squad-sprint-board-6010683afabec1001a090887/issues/valora-inc/in-house-liquidity/585)