### PR TITLE
chore(npm): Add instructions for publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.

--- a/README.md
+++ b/README.md
@@ -11,3 +11,16 @@ yarn test
 ## Contributing
 
 We welcome contributions in the form of Issues and PRs. See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+### Publishing
+
+- Request access to our [NPM organization](https://www.npmjs.com/org/fiatconnect) on [Valora Discord](https://discord.gg/rwxxsZjJbd)
+- Make sure you are on the latest version of branch `main`
+- Check out a release branch
+- Run `yarn prepublish && yarn release`
+- Add release notes to `CHANGELOG.md`
+- Once code review has taken place:
+  - Merge your branch
+  - Run `git tag vX.Y.Z && git push origin vX.Y.Z` to push your tag (where X.Y.Z is the version you are trying to publish)
+  - [Create a release](https://github.com/fiatconnect/fiatconnect-sdk/releases) with the new tag
+  - Run `npm publish --public`

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "fiatconnect-sdk",
-  "version": "1.0.0",
+  "name": "@fiatconnect/fiatconnect-sdk",
+  "version": "0.1.0",
   "description": "A helper libary for wallets to integrate with FiatConnect APIs",
   "scripts": {
     "format": "prettier --loglevel error --write \"./**/*.ts\"",
     "prepublish": "tsc",
     "lint": "eslint --ext=.ts src/",
-    "release": "standard-version",
+    "release": "standard-version --skip.tag",
     "test": "jest",
     "prepare": "husky install"
   },
@@ -18,12 +18,15 @@
     "celo"
   ],
   "main": "dist/index.js",
-  "repository": "https://github.com/fiatconnect/fiatconnect-sdk",
+  "types": "dist/types.d.ts",
+  "repository": "git@github.com:fiatconnect/fiatconnect-sdk.git",
   "author": "Jacob Waterman <jacob.waterman@valoraapp.com>",
   "bugs": {
     "url": "https://github.com/fiatconnect/fiatconnect-sdk/issues"
   },
+  "homepage": "https://github.com/fiatconnect/fiatconnect-sdk#readme",
   "license": "MIT",
+  "private": false,
   "devDependencies": {
     "@types/jest": "^27.4.1",
     "@types/node-fetch": "^2.6.1",


### PR DESCRIPTION
Adds instructions and changes to package.json for publishing the initial version of this package to NPM. Setting the initial version at v0.1.0 as per [Semantic Versioning guidelines](https://semver.org/#how-should-i-deal-with-revisions-in-the-0yz-initial-development-phase), though we should plan on moving to v1.y.z soon. Once this is merged, I'll publish the initial version to NPM!