### PR TITLE
feat(login): Add isLoggedIn, minor fixes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import {
   AddFiatAccountParams,
   AddKycParams,
   ErrorResponse,
-  FiatConectApiClient,
+  FiatConnectApiClient,
   FiatConnectClientConfig,
   TransferRequestParams,
   ClockDiffParams,
@@ -37,7 +37,7 @@ const SESSION_DURATION_MS = 14400000 // 4 hours
 
 const fetch = fetchCookie(nodeFetch)
 
-export default class FiatConnectClient implements FiatConectApiClient {
+export default class FiatConnectClient implements FiatConnectApiClient {
   config: FiatConnectClientConfig
   signingFunction: (message: string) => Promise<string>
   _sessionExpiry?: Date
@@ -57,13 +57,22 @@ export default class FiatConnectClient implements FiatConectApiClient {
   }
 
   async _ensureLogin() {
-    if (this._sessionExpiry && this._sessionExpiry > new Date()) {
+    if (this.isLoggedIn()) {
       return
     }
     const loginResult = await this.login()
     if (!loginResult.ok) {
       throw new Error(`Login failed: ${loginResult.val.error}`)
     }
+  }
+
+  /**
+   * Checks if a logged in session exists with the provider.
+   *
+   * @returns true if an unexpired session exists with the provider, else false
+   */
+  isLoggedIn(): boolean {
+    return !!(this._sessionExpiry && this._sessionExpiry > new Date())
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,9 +21,11 @@ import {
 } from '@fiatconnect/fiatconnect-types'
 import { Result } from 'ts-results'
 
-export interface FiatConectApiClient {
+export interface FiatConnectApiClient {
   getClockDiffApprox(): Promise<Result<ClockDiffResult, ErrorResponse>>
   getClock(): Promise<Result<ClockResponse, ErrorResponse>>
+  login(): Promise<Result<'success', ErrorResponse>>
+  isLoggedIn(): boolean
   getQuoteIn(
     params: QuoteRequestQuery,
     jwt: string,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -229,6 +229,23 @@ describe('FiatConnect SDK', () => {
       expect(getHeadersMock).not.toHaveBeenCalled()
     })
   })
+  describe('isLoggedIn', () => {
+    it('returns false when sessionExpiry does not exist', () => {
+      expect(client.isLoggedIn()).toBeFalsy()
+    })
+    it('returns false when sessionExpiry exists but is too old', () => {
+      client._sessionExpiry = new Date('2022-05-01T00:00:00+0000')
+      const mockNow = new Date('2022-05-02T00:00:00+0000').getTime()
+      jest.spyOn(global.Date, 'now').mockReturnValueOnce(mockNow)
+      expect(client.isLoggedIn()).toBeFalsy()
+    })
+    it('returns true when sessionExpiry exists and is not too old', () => {
+      client._sessionExpiry = new Date('2022-05-03T00:00:00+0000')
+      const mockNow = new Date('2022-05-02T00:00:00+0000').getTime()
+      jest.spyOn(global.Date, 'now').mockReturnValueOnce(mockNow)
+      expect(client.isLoggedIn()).toBeTruthy()
+    })
+  })
   describe('_ensureLogin', () => {
     const mockLogin = jest.spyOn(client, 'login')
     it('calls login and returns successfully if sessionExpiry is not set', async () => {


### PR DESCRIPTION
Half of #18. Primarily adds a new method `isLoggedIn` and exposes it to clients, but also has two (very minor) fixes tacked on.

* Add new method `isLoggedIn` to `FiatConnectClient` for use in the wallet
* Update `FiatConnectApiClient` interface to include `login`
* Update typo'd `FiatConectApiClient` to `FiatConnectApiClient`