### PR TITLE
fix(constructor): Remove unused constructor fields

### DIFF
--- a/src/fiat-connect-client.ts
+++ b/src/fiat-connect-client.ts
@@ -39,12 +39,12 @@ const fetch = fetchCookie(nodeFetch)
 
 export class FiatConnectClient implements FiatConnectApiClient {
   config: FiatConnectClientConfig
-  signingFunction: (message: string) => Promise<string>
+  signingFunction?: (message: string) => Promise<string>
   _sessionExpiry?: Date
 
   constructor(
     config: FiatConnectClientConfig,
-    signingFunction: (message: string) => Promise<string>,
+    signingFunction?: (message: string) => Promise<string>,
   ) {
     this.config = config
     this.signingFunction = signingFunction
@@ -83,6 +83,15 @@ export class FiatConnectClient implements FiatConnectApiClient {
    */
   async login(): Promise<Result<'success', ErrorResponse>> {
     try {
+      if(!this.config.accountAddress) {
+        throw new Error('Missing the accountAddress field in the FiatConnectClient constructor')
+      }
+      if(!this.config.network) {
+        throw new Error('Missing the network field in the FiatConnectClient constructor')
+      }
+      if(!this.signingFunction) {
+        throw new Error('Missing the signingFunction in the FiatConnectClient constructor')
+      }
       const expirationDate = new Date(Date.now() + SESSION_DURATION_MS)
       const siweMessage = new SiweMessage({
         domain: new URL(this.config.baseUrl).hostname,

--- a/src/fiat-connect-client.ts
+++ b/src/fiat-connect-client.ts
@@ -83,14 +83,20 @@ export class FiatConnectClient implements FiatConnectApiClient {
    */
   async login(): Promise<Result<'success', ErrorResponse>> {
     try {
-      if(!this.config.accountAddress) {
-        throw new Error('Missing the accountAddress field in the FiatConnectClient constructor')
+      if (!this.config.accountAddress) {
+        throw new Error(
+          'Missing the accountAddress field in the FiatConnectClient constructor',
+        )
       }
-      if(!this.config.network) {
-        throw new Error('Missing the network field in the FiatConnectClient constructor')
+      if (!this.config.network) {
+        throw new Error(
+          'Missing the network field in the FiatConnectClient constructor',
+        )
       }
-      if(!this.signingFunction) {
-        throw new Error('Missing the signingFunction in the FiatConnectClient constructor')
+      if (!this.signingFunction) {
+        throw new Error(
+          'Missing the signingFunction in the FiatConnectClient constructor',
+        )
       }
       const expirationDate = new Date(Date.now() + SESSION_DURATION_MS)
       const siweMessage = new SiweMessage({

--- a/src/fiat-connect-client.ts
+++ b/src/fiat-connect-client.ts
@@ -39,12 +39,12 @@ const fetch = fetchCookie(nodeFetch)
 
 export class FiatConnectClient implements FiatConnectApiClient {
   config: FiatConnectClientConfig
-  signingFunction?: (message: string) => Promise<string>
+  signingFunction: (message: string) => Promise<string>
   _sessionExpiry?: Date
 
   constructor(
     config: FiatConnectClientConfig,
-    signingFunction?: (message: string) => Promise<string>,
+    signingFunction: (message: string) => Promise<string>,
   ) {
     this.config = config
     this.signingFunction = signingFunction
@@ -83,21 +83,6 @@ export class FiatConnectClient implements FiatConnectApiClient {
    */
   async login(): Promise<Result<'success', ErrorResponse>> {
     try {
-      if (!this.config.accountAddress) {
-        throw new Error(
-          'Missing the accountAddress field in the FiatConnectClient constructor',
-        )
-      }
-      if (!this.config.network) {
-        throw new Error(
-          'Missing the network field in the FiatConnectClient constructor',
-        )
-      }
-      if (!this.signingFunction) {
-        throw new Error(
-          'Missing the signingFunction in the FiatConnectClient constructor',
-        )
-      }
       const expirationDate = new Date(Date.now() + SESSION_DURATION_MS)
       const siweMessage = new SiweMessage({
         domain: new URL(this.config.baseUrl).hostname,

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,8 +87,8 @@ export interface AddFiatAccountParams {
 
 export interface FiatConnectClientConfig {
   baseUrl: string
-  network?: Network
-  accountAddress?: string
+  network: Network
+  accountAddress: string
   apiKey?: string
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,10 +87,8 @@ export interface AddFiatAccountParams {
 
 export interface FiatConnectClientConfig {
   baseUrl: string
-  providerName: string
-  iconUrl: string
-  network: Network
-  accountAddress: string
+  network?: Network
+  accountAddress?: string
   apiKey?: string
 }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -219,51 +219,6 @@ describe('FiatConnect SDK', () => {
       expect(response.val).toEqual({ error: 'sign error' })
       expect(getHeadersMock).not.toHaveBeenCalled()
     })
-    it('returns error if network is not in the config', async () => {
-      const noNetworkClient = new FiatConnectClient(
-        {
-          baseUrl: 'https://fiat-connect-api.com',
-          accountAddress,
-        },
-        signingFunction,
-      )
-      const response = await noNetworkClient.login()
-
-      expect(response.ok).toBeFalsy()
-      expect(response.val).toEqual({
-        error: 'Missing the network field in the FiatConnectClient constructor',
-      })
-    })
-    it('returns error if accountAddress is not in the config', async () => {
-      const noAddressClient = new FiatConnectClient(
-        {
-          baseUrl: 'https://fiat-connect-api.com',
-          network: Network.Alfajores,
-        },
-        signingFunction,
-      )
-      const response = await noAddressClient.login()
-
-      expect(response.ok).toBeFalsy()
-      expect(response.val).toEqual({
-        error:
-          'Missing the accountAddress field in the FiatConnectClient constructor',
-      })
-    })
-    it('returns error if signingFunction is not in the config', async () => {
-      const noSigningFunctionClient = new FiatConnectClient({
-        baseUrl: 'https://fiat-connect-api.com',
-        network: Network.Alfajores,
-        accountAddress,
-      })
-      const response = await noSigningFunctionClient.login()
-
-      expect(response.ok).toBeFalsy()
-      expect(response.val).toEqual({
-        error:
-          'Missing the signingFunction in the FiatConnectClient constructor',
-      })
-    })
   })
   describe('isLoggedIn', () => {
     it('returns false when sessionExpiry does not exist', () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -230,7 +230,9 @@ describe('FiatConnect SDK', () => {
       const response = await noNetworkClient.login()
 
       expect(response.ok).toBeFalsy()
-      expect(response.val).toEqual({ error: 'Missing the network field in the FiatConnectClient constructor' })
+      expect(response.val).toEqual({
+        error: 'Missing the network field in the FiatConnectClient constructor',
+      })
     })
     it('returns error if accountAddress is not in the config', async () => {
       const noAddressClient = new FiatConnectClient(
@@ -243,20 +245,24 @@ describe('FiatConnect SDK', () => {
       const response = await noAddressClient.login()
 
       expect(response.ok).toBeFalsy()
-      expect(response.val).toEqual({ error: 'Missing the accountAddress field in the FiatConnectClient constructor' })
+      expect(response.val).toEqual({
+        error:
+          'Missing the accountAddress field in the FiatConnectClient constructor',
+      })
     })
     it('returns error if signingFunction is not in the config', async () => {
-      const noSigningFunctionClient = new FiatConnectClient(
-        {
-          baseUrl: 'https://fiat-connect-api.com',
-          network: Network.Alfajores,
-          accountAddress
-        }
-      )
+      const noSigningFunctionClient = new FiatConnectClient({
+        baseUrl: 'https://fiat-connect-api.com',
+        network: Network.Alfajores,
+        accountAddress,
+      })
       const response = await noSigningFunctionClient.login()
 
       expect(response.ok).toBeFalsy()
-      expect(response.val).toEqual({ error: 'Missing the signingFunction in the FiatConnectClient constructor' })
+      expect(response.val).toEqual({
+        error:
+          'Missing the signingFunction in the FiatConnectClient constructor',
+      })
     })
   })
   describe('isLoggedIn', () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -35,8 +35,6 @@ jest.mock('siwe', () => ({
 }))
 
 describe('FiatConnect SDK', () => {
-    'https://storage.googleapis.com/celo-mobile-mainnet.appspot.com/images/valora-icon.png'
-  const exampleProviderName = 'Example Provider'
   const accountAddress = '0x0d8e461687b7d06f86ec348e0c270b0f279855f0'
   const checksummedAccountAddress = '0x0D8e461687b7D06f86EC348E0c270b0F279855F0'
   const signingFunction = jest.fn(() => Promise.resolve('signed message'))


### PR DESCRIPTION
* providerName and iconUrl were simply not used anywhere, i think its over-prescriptive to force them to be part of the SDK so I removed them