### PR TITLE
feat(result): Replace Result implementation, simplify errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
+    "@badrap/result": "^0.2.12",
     "@fiatconnect/fiatconnect-types": "^4.0.0",
     "ethers": "^5.6.4",
     "fetch-cookie": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "fetch-cookie": "^2.0.3",
     "node-fetch": "^2.6.6",
     "siwe": "^1.1.6",
-    "ts-results": "^3.3.0",
     "tslib": "^2.4.0"
   }
 }

--- a/src/fiat-connect-client.ts
+++ b/src/fiat-connect-client.ts
@@ -451,13 +451,14 @@ export class FiatConnectClient implements FiatConnectApiClient {
 
 /**
  * handleError accepts three types of inputs:
- *  * an ResponseError object
+ *  * a ResponseError object
  *  * a built-in Error object
- *  * A JSON payload from a failed FiatConnect API call
+ *  * A JSON payload from a non-200 FiatConnect API call
  *
  * handleError converts all of these into ResponseError objects wrapped
  * in a Result.err. If handleError is given data of a type not listed above,
- * it attempts to cast it to a string and return a generic ResponseError with it.
+ * it attempts to cast it to a string, put it in a ResponseError object, and
+ * wrap it in a Result.err.
  **/
 function handleError(error: unknown): Result<any, ResponseError> {
   if (error instanceof ResponseError) {

--- a/src/fiat-connect-client.ts
+++ b/src/fiat-connect-client.ts
@@ -461,6 +461,7 @@ export class FiatConnectClient implements FiatConnectApiClient {
  * wrap it in a Result.err.
  **/
 function handleError<T>(error: unknown): Result<T, ResponseError> {
+  // TODO: expose trace to make these errors more useful for clients
   if (error instanceof ResponseError) {
     return Result.err(error)
   } else if (error instanceof Error) {

--- a/src/fiat-connect-client.ts
+++ b/src/fiat-connect-client.ts
@@ -460,11 +460,11 @@ export class FiatConnectClient implements FiatConnectApiClient {
  * it attempts to cast it to a string, put it in a ResponseError object, and
  * wrap it in a Result.err.
  **/
-function handleError(error: unknown): Result<any, ResponseError> {
+function handleError<T>(error: unknown): Result<T, ResponseError> {
   if (error instanceof ResponseError) {
     return Result.err(error)
   } else if (error instanceof Error) {
-    return Result.err(new ResponseError(error.message, undefined))
+    return Result.err(new ResponseError(error.message))
   } else if (error instanceof Object) {
     // We cast to QuoteErrorResponse here since it is a strict superset of all other
     // error response objects, allowing us to access all possible error-related fields.
@@ -472,5 +472,5 @@ function handleError(error: unknown): Result<any, ResponseError> {
       new ResponseError('FiatConnect API Error', error as QuoteErrorResponse),
     )
   }
-  return Result.err(new ResponseError(String(error), undefined))
+  return Result.err(new ResponseError(String(error)))
 }

--- a/src/fiat-connect-client.ts
+++ b/src/fiat-connect-client.ts
@@ -17,11 +17,11 @@ import {
 import fetchCookie from 'fetch-cookie'
 import nodeFetch from 'node-fetch'
 import { generateNonce, SiweMessage } from 'siwe'
-import { Ok, Err, Result } from 'ts-results'
+import { Result } from '@badrap/result'
 import {
   AddFiatAccountParams,
   AddKycParams,
-  ErrorResponse,
+  ResponseError,
   FiatConnectApiClient,
   FiatConnectClientConfig,
   TransferRequestParams,
@@ -61,8 +61,8 @@ export class FiatConnectClient implements FiatConnectApiClient {
       return
     }
     const loginResult = await this.login()
-    if (!loginResult.ok) {
-      throw new Error(`Login failed: ${loginResult.val.error}`)
+    if (loginResult.isErr) {
+      throw loginResult.error
     }
   }
 
@@ -81,7 +81,7 @@ export class FiatConnectClient implements FiatConnectApiClient {
    * @returns a Promise resolving to the literal string 'success' on a
    * successful login or an Error response.
    */
-  async login(): Promise<Result<'success', ErrorResponse>> {
+  async login(): Promise<Result<'success', ResponseError>> {
     try {
       const expirationDate = new Date(Date.now() + SESSION_DURATION_MS)
       const siweMessage = new SiweMessage({
@@ -112,11 +112,11 @@ export class FiatConnectClient implements FiatConnectApiClient {
       if (!response.ok) {
         // On a non 200 response, the response should be a JSON including an error field.
         const data = await response.json()
-        return Err(data as ErrorResponse)
+        return handleError(data)
       }
 
       this._sessionExpiry = expirationDate
-      return Ok('success')
+      return Result.ok('success')
     } catch (error) {
       return handleError(error)
     }
@@ -125,7 +125,7 @@ export class FiatConnectClient implements FiatConnectApiClient {
   async _getQuote(
     params: QuoteRequestQuery,
     inOrOut: 'in' | 'out',
-  ): Promise<Result<QuoteResponse, QuoteErrorResponse | ErrorResponse>> {
+  ): Promise<Result<QuoteResponse, ResponseError>> {
     try {
       const queryParams = new URLSearchParams(params).toString()
       const response = await fetch(
@@ -137,9 +137,9 @@ export class FiatConnectClient implements FiatConnectApiClient {
       )
       const data = await response.json()
       if (!response.ok) {
-        return Err(data as QuoteErrorResponse)
+        return handleError(data)
       }
-      return Ok(data as QuoteResponse)
+      return Result.ok(data as QuoteResponse)
     } catch (error) {
       return handleError(error)
     }
@@ -162,25 +162,25 @@ export class FiatConnectClient implements FiatConnectApiClient {
   /**
    * Convenience method to calculate the approximate difference between server and client clocks.
    */
-  async getClockDiffApprox(): Promise<Result<ClockDiffResult, ErrorResponse>> {
+  async getClockDiffApprox(): Promise<Result<ClockDiffResult, ResponseError>> {
     const t0 = Date.now()
     const clockResponse = await this.getClock()
     const t3 = Date.now()
 
-    if (!clockResponse.ok) {
-      return clockResponse
+    if (!clockResponse.isOk) {
+      return Result.err(clockResponse.error)
     }
 
-    const t1 = new Date(clockResponse.val.time).getTime()
+    const t1 = new Date(clockResponse.value.time).getTime()
     // We can assume that t1 and t2 are sufficiently close to each other
     const t2 = t1
-    return Ok(this._calculateClockDiff({ t0, t1, t2, t3 }))
+    return Result.ok(this._calculateClockDiff({ t0, t1, t2, t3 }))
   }
 
   /**
    * https://github.com/fiatconnect/specification/blob/main/fiatconnect-api.md#321-get-clock
    */
-  async getClock(): Promise<Result<ClockResponse, ErrorResponse>> {
+  async getClock(): Promise<Result<ClockResponse, ResponseError>> {
     try {
       const response = await fetch(`${this.config.baseUrl}/clock`, {
         method: 'GET',
@@ -188,9 +188,9 @@ export class FiatConnectClient implements FiatConnectApiClient {
       })
       const data = await response.json()
       if (!response.ok) {
-        return Err(data)
+        return handleError(data)
       }
-      return Ok(data)
+      return Result.ok(data)
     } catch (error) {
       return handleError(error)
     }
@@ -201,7 +201,7 @@ export class FiatConnectClient implements FiatConnectApiClient {
    */
   async getQuoteIn(
     params: QuoteRequestQuery,
-  ): Promise<Result<QuoteResponse, QuoteErrorResponse | ErrorResponse>> {
+  ): Promise<Result<QuoteResponse, ResponseError>> {
     return this._getQuote(params, 'in')
   }
 
@@ -210,7 +210,7 @@ export class FiatConnectClient implements FiatConnectApiClient {
    */
   async getQuoteOut(
     params: QuoteRequestQuery,
-  ): Promise<Result<QuoteResponse, QuoteErrorResponse | ErrorResponse>> {
+  ): Promise<Result<QuoteResponse, ResponseError>> {
     return this._getQuote(params, 'out')
   }
 
@@ -219,7 +219,7 @@ export class FiatConnectClient implements FiatConnectApiClient {
    */
   async addKyc(
     params: AddKycParams,
-  ): Promise<Result<KycStatusResponse, ErrorResponse>> {
+  ): Promise<Result<KycStatusResponse, ResponseError>> {
     try {
       await this._ensureLogin()
       const response = await fetch(
@@ -235,9 +235,9 @@ export class FiatConnectClient implements FiatConnectApiClient {
       )
       const data = await response.json()
       if (!response.ok) {
-        return Err(data)
+        return handleError(data)
       }
-      return Ok(data)
+      return Result.ok(data)
     } catch (error) {
       return handleError(error)
     }
@@ -248,7 +248,7 @@ export class FiatConnectClient implements FiatConnectApiClient {
    */
   async deleteKyc(
     params: KycRequestParams,
-  ): Promise<Result<void, ErrorResponse>> {
+  ): Promise<Result<void, ResponseError>> {
     try {
       await this._ensureLogin()
       const response = await fetch(
@@ -260,9 +260,9 @@ export class FiatConnectClient implements FiatConnectApiClient {
       )
       const data = await response.json()
       if (!response.ok) {
-        return Err(data)
+        return handleError(data)
       }
-      return Ok(undefined)
+      return Result.ok(undefined)
     } catch (error) {
       return handleError(error)
     }
@@ -273,7 +273,7 @@ export class FiatConnectClient implements FiatConnectApiClient {
    */
   async getKycStatus(
     params: KycRequestParams,
-  ): Promise<Result<KycStatusResponse, ErrorResponse>> {
+  ): Promise<Result<KycStatusResponse, ResponseError>> {
     try {
       await this._ensureLogin()
       const response = await fetch(
@@ -285,9 +285,9 @@ export class FiatConnectClient implements FiatConnectApiClient {
       )
       const data = await response.json()
       if (!response.ok) {
-        return Err(data)
+        return handleError(data)
       }
-      return Ok(data)
+      return Result.ok(data)
     } catch (error) {
       return handleError(error)
     }
@@ -298,7 +298,7 @@ export class FiatConnectClient implements FiatConnectApiClient {
    */
   async addFiatAccount(
     params: AddFiatAccountParams,
-  ): Promise<Result<AddFiatAccountResponse, ErrorResponse>> {
+  ): Promise<Result<AddFiatAccountResponse, ResponseError>> {
     try {
       await this._ensureLogin()
       const response = await fetch(
@@ -314,9 +314,9 @@ export class FiatConnectClient implements FiatConnectApiClient {
       )
       const data = await response.json()
       if (!response.ok) {
-        return Err(data)
+        return handleError(data)
       }
-      return Ok(data)
+      return Result.ok(data)
     } catch (error) {
       return handleError(error)
     }
@@ -326,7 +326,7 @@ export class FiatConnectClient implements FiatConnectApiClient {
    * https://github.com/fiatconnect/specification/blob/main/fiatconnect-api.md#3332-get-accounts
    */
   async getFiatAccounts(): Promise<
-    Result<GetFiatAccountsResponse, ErrorResponse>
+    Result<GetFiatAccountsResponse, ResponseError>
   > {
     try {
       await this._ensureLogin()
@@ -336,9 +336,9 @@ export class FiatConnectClient implements FiatConnectApiClient {
       })
       const data = await response.json()
       if (!response.ok) {
-        return Err(data)
+        return handleError(data)
       }
-      return Ok(data)
+      return Result.ok(data)
     } catch (error) {
       return handleError(error)
     }
@@ -349,7 +349,7 @@ export class FiatConnectClient implements FiatConnectApiClient {
    */
   async deleteFiatAccount(
     params: DeleteFiatAccountRequestParams,
-  ): Promise<Result<void, ErrorResponse>> {
+  ): Promise<Result<void, ResponseError>> {
     try {
       await this._ensureLogin()
       const response = await fetch(
@@ -361,9 +361,9 @@ export class FiatConnectClient implements FiatConnectApiClient {
       )
       const data = await response.json()
       if (!response.ok) {
-        return Err(data)
+        return handleError(data)
       }
-      return Ok(undefined)
+      return Result.ok(undefined)
     } catch (error) {
       return handleError(error)
     }
@@ -374,7 +374,7 @@ export class FiatConnectClient implements FiatConnectApiClient {
    */
   async transferIn(
     params: TransferRequestParams,
-  ): Promise<Result<TransferResponse, ErrorResponse>> {
+  ): Promise<Result<TransferResponse, ResponseError>> {
     try {
       await this._ensureLogin()
       const response = await fetch(`${this.config.baseUrl}/transfer/in`, {
@@ -388,9 +388,9 @@ export class FiatConnectClient implements FiatConnectApiClient {
       })
       const data = await response.json()
       if (!response.ok) {
-        return Err(data)
+        return handleError(data)
       }
-      return Ok(data)
+      return Result.ok(data)
     } catch (error) {
       return handleError(error)
     }
@@ -401,7 +401,7 @@ export class FiatConnectClient implements FiatConnectApiClient {
    */
   async transferOut(
     params: TransferRequestParams,
-  ): Promise<Result<TransferResponse, ErrorResponse>> {
+  ): Promise<Result<TransferResponse, ResponseError>> {
     try {
       await this._ensureLogin()
       const response = await fetch(`${this.config.baseUrl}/transfer/out`, {
@@ -415,9 +415,9 @@ export class FiatConnectClient implements FiatConnectApiClient {
       })
       const data = await response.json()
       if (!response.ok) {
-        return Err(data)
+        return handleError(data)
       }
-      return Ok(data)
+      return Result.ok(data)
     } catch (error) {
       return handleError(error)
     }
@@ -428,7 +428,7 @@ export class FiatConnectClient implements FiatConnectApiClient {
    */
   async getTransferStatus(
     params: TransferStatusRequestParams,
-  ): Promise<Result<TransferStatusResponse, ErrorResponse>> {
+  ): Promise<Result<TransferStatusResponse, ResponseError>> {
     try {
       await this._ensureLogin()
       const response = await fetch(
@@ -440,18 +440,36 @@ export class FiatConnectClient implements FiatConnectApiClient {
       )
       const data = await response.json()
       if (!response.ok) {
-        return Err(data)
+        return handleError(data)
       }
-      return Ok(data)
+      return Result.ok(data)
     } catch (error) {
       return handleError(error)
     }
   }
 }
 
-function handleError(error: unknown): Err<ErrorResponse> {
-  if (error instanceof Error) {
-    return Err({ ...error, error: error.message })
+/**
+ * handleError accepts three types of inputs:
+ *  * an ResponseError object
+ *  * a built-in Error object
+ *  * A JSON payload from a failed FiatConnect API call
+ *
+ * handleError converts all of these into ResponseError objects wrapped
+ * in a Result.err. If handleError is given data of a type not listed above,
+ * it attempts to cast it to a string and return a generic ResponseError with it.
+ **/
+function handleError(error: unknown): Result<any, ResponseError> {
+  if (error instanceof ResponseError) {
+    return Result.err(error)
+  } else if (error instanceof Error) {
+    return Result.err(new ResponseError(error.message, undefined))
+  } else if (error instanceof Object) {
+    // We cast to QuoteErrorResponse here since it is a strict superset of all other
+    // error response objects, allowing us to access all possible error-related fields.
+    return Result.err(
+      new ResponseError('FiatConnect API Error', error as QuoteErrorResponse),
+    )
   }
-  return Err({ error: String(error) })
+  return Result.err(new ResponseError(String(error), undefined))
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,56 +21,56 @@ import {
   TransferStatusResponse,
   ClockResponse,
 } from '@fiatconnect/fiatconnect-types'
-import { Result } from 'ts-results'
+import { Result } from '@badrap/result'
 
 export interface FiatConnectApiClient {
-  getClockDiffApprox(): Promise<Result<ClockDiffResult, ErrorResponse>>
-  getClock(): Promise<Result<ClockResponse, ErrorResponse>>
-  login(): Promise<Result<'success', ErrorResponse>>
+  getClockDiffApprox(): Promise<Result<ClockDiffResult, ResponseError>>
+  getClock(): Promise<Result<ClockResponse, ResponseError>>
+  login(): Promise<Result<'success', ResponseError>>
   isLoggedIn(): boolean
   getQuoteIn(
     params: QuoteRequestQuery,
     jwt: string,
-  ): Promise<Result<QuoteResponse, QuoteErrorResponse | ErrorResponse>>
+  ): Promise<Result<QuoteResponse, ResponseError>>
   getQuoteOut(
     params: QuoteRequestQuery,
     jwt: string,
-  ): Promise<Result<QuoteResponse, QuoteErrorResponse | ErrorResponse>>
+  ): Promise<Result<QuoteResponse, ResponseError>>
   addKyc(
     params: AddKycParams,
     jwt: string,
-  ): Promise<Result<KycStatusResponse, ErrorResponse>>
+  ): Promise<Result<KycStatusResponse, ResponseError>>
   deleteKyc(
     params: KycRequestParams,
     jwt: string,
-  ): Promise<Result<void, ErrorResponse>>
+  ): Promise<Result<void, ResponseError>>
   getKycStatus(
     params: KycRequestParams,
     jwt: string,
-  ): Promise<Result<KycStatusResponse, ErrorResponse>>
+  ): Promise<Result<KycStatusResponse, ResponseError>>
   addFiatAccount(
     params: AddFiatAccountParams,
     jwt: string,
-  ): Promise<Result<AddFiatAccountResponse, ErrorResponse>>
+  ): Promise<Result<AddFiatAccountResponse, ResponseError>>
   getFiatAccounts(
     jwt: string,
-  ): Promise<Result<GetFiatAccountsResponse, ErrorResponse>>
+  ): Promise<Result<GetFiatAccountsResponse, ResponseError>>
   deleteFiatAccount(
     params: DeleteFiatAccountRequestParams,
     jwt: string,
-  ): Promise<Result<void, ErrorResponse>>
+  ): Promise<Result<void, ResponseError>>
   transferIn(
     params: TransferRequestParams,
     jwt: string,
-  ): Promise<Result<TransferResponse, ErrorResponse>>
+  ): Promise<Result<TransferResponse, ResponseError>>
   transferOut(
     params: TransferRequestParams,
     jwt: string,
-  ): Promise<Result<TransferResponse, ErrorResponse>>
+  ): Promise<Result<TransferResponse, ResponseError>>
   getTransferStatus(
     params: TransferStatusRequestParams,
     jwt: string,
-  ): Promise<Result<TransferStatusResponse, ErrorResponse>>
+  ): Promise<Result<TransferStatusResponse, ResponseError>>
 }
 
 // These must be manually updated as more KYC and FiatAccount types become standardized
@@ -96,10 +96,6 @@ export interface FiatConnectClientConfig {
   apiKey?: string
 }
 
-export interface ErrorResponse {
-  error: FiatConnectError | string
-}
-
 export interface TransferRequestParams {
   idempotencyKey: string
   data: TransferRequestBody
@@ -115,4 +111,32 @@ export interface ClockDiffParams {
 export interface ClockDiffResult {
   diff: number
   maxError: number
+}
+
+// ResponseError is an error object that can act as a general error
+// as well as contain details about a FiatConnect-specific error from
+// an API.
+export class ResponseError extends Error {
+  fiatConnectError: FiatConnectError | undefined
+
+  minimumFiatAmount: string | undefined
+  maximumFiatAmount: string | undefined
+  minimumCryptoAmount: string | undefined
+  maximumCryptoAmount: string | undefined
+
+  // Because QuoteErrorResponse contains the `error` field (the only field returned
+  // by all other endpoints on error) as well as additional quote-specific error
+  // fields, we use it as the data type here.
+  constructor(message: string, data: QuoteErrorResponse | undefined) {
+    super(message)
+    Object.setPrototypeOf(this, ResponseError.prototype)
+
+    if (data) {
+      this.fiatConnectError = data?.error
+      this.minimumFiatAmount = data?.minimumFiatAmount
+      this.maximumFiatAmount = data?.maximumFiatAmount
+      this.minimumCryptoAmount = data?.minimumCryptoAmount
+      this.maximumCryptoAmount = data?.maximumCryptoAmount
+    }
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,26 +117,24 @@ export interface ClockDiffResult {
 // as well as contain details about a FiatConnect-specific error from
 // an API.
 export class ResponseError extends Error {
-  fiatConnectError: FiatConnectError | undefined
+  fiatConnectError?: FiatConnectError
 
-  minimumFiatAmount: string | undefined
-  maximumFiatAmount: string | undefined
-  minimumCryptoAmount: string | undefined
-  maximumCryptoAmount: string | undefined
+  minimumFiatAmount?: string
+  maximumFiatAmount?: string
+  minimumCryptoAmount?: string
+  maximumCryptoAmount?: string
 
   // Because QuoteErrorResponse contains the `error` field (the only field returned
   // by all other endpoints on error) as well as additional quote-specific error
   // fields, we use it as the data type here.
-  constructor(message: string, data: QuoteErrorResponse | undefined) {
+  constructor(message: string, data?: QuoteErrorResponse) {
     super(message)
     Object.setPrototypeOf(this, ResponseError.prototype)
 
-    if (data) {
-      this.fiatConnectError = data?.error
-      this.minimumFiatAmount = data?.minimumFiatAmount
-      this.maximumFiatAmount = data?.maximumFiatAmount
-      this.minimumCryptoAmount = data?.minimumCryptoAmount
-      this.maximumCryptoAmount = data?.maximumCryptoAmount
-    }
+    this.fiatConnectError = data?.error
+    this.minimumFiatAmount = data?.minimumFiatAmount
+    this.maximumFiatAmount = data?.maximumFiatAmount
+    this.minimumCryptoAmount = data?.minimumCryptoAmount
+    this.maximumCryptoAmount = data?.maximumCryptoAmount
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -145,7 +145,7 @@ describe('FiatConnect SDK', () => {
 
       expect(response.isOk).toBeFalsy()
       expect(response.unwrap.bind(response)).toThrow(
-        new ResponseError('fake error message', undefined),
+        new ResponseError('fake error message'),
       )
     })
   })
@@ -230,7 +230,7 @@ describe('FiatConnect SDK', () => {
 
       expect(response.isOk).toBeFalsy()
       expect(response.unwrap.bind(response)).toThrow(
-        new ResponseError('some error', undefined),
+        new ResponseError('some error'),
       )
       expect(getHeadersMock).not.toHaveBeenCalled()
     })
@@ -267,11 +267,11 @@ describe('FiatConnect SDK', () => {
     })
     it('throws error if login fails', async () => {
       mockLogin.mockResolvedValueOnce(
-        Result.err(new ResponseError('some error', undefined)),
+        Result.err(new ResponseError('some error')),
       )
       await expect(async () => {
         await client._ensureLogin()
-      }).rejects.toThrow(new ResponseError('some error', undefined))
+      }).rejects.toThrow(new ResponseError('some error'))
       expect(mockLogin).toHaveBeenCalledTimes(1)
     })
   })
@@ -325,7 +325,7 @@ describe('FiatConnect SDK', () => {
 
       expect(response.isOk).toBeFalsy()
       expect(response.unwrap.bind(response)).toThrow(
-        new ResponseError('fake error message', undefined),
+        new ResponseError('fake error message'),
       )
     })
   })
@@ -358,7 +358,7 @@ describe('FiatConnect SDK', () => {
 
       expect(response.isOk).toBeFalsy()
       expect(response.unwrap.bind(response)).toThrow(
-        new ResponseError('fake error message', undefined),
+        new ResponseError('fake error message'),
       )
     })
   })
@@ -428,7 +428,7 @@ describe('FiatConnect SDK', () => {
       })
       expect(response.isOk).toBeFalsy()
       expect(response.unwrap.bind(response)).toThrow(
-        new ResponseError('fake error message', undefined),
+        new ResponseError('fake error message'),
       )
     })
   })
@@ -470,7 +470,7 @@ describe('FiatConnect SDK', () => {
       })
       expect(response.isOk).toBeFalsy()
       expect(response.unwrap.bind(response)).toThrow(
-        new ResponseError('fake error message', undefined),
+        new ResponseError('fake error message'),
       )
     })
   })
@@ -512,7 +512,7 @@ describe('FiatConnect SDK', () => {
       })
       expect(response.isOk).toBeFalsy()
       expect(response.unwrap.bind(response)).toThrow(
-        new ResponseError('fake error message', undefined),
+        new ResponseError('fake error message'),
       )
     })
   })
@@ -582,7 +582,7 @@ describe('FiatConnect SDK', () => {
       })
       expect(response.isOk).toBeFalsy()
       expect(response.unwrap.bind(response)).toThrow(
-        new ResponseError('fake error message', undefined),
+        new ResponseError('fake error message'),
       )
     })
   })
@@ -618,7 +618,7 @@ describe('FiatConnect SDK', () => {
       const response = await client.getFiatAccounts()
       expect(response.isOk).toBeFalsy()
       expect(response.unwrap.bind(response)).toThrow(
-        new ResponseError('fake error message', undefined),
+        new ResponseError('fake error message'),
       )
     })
   })
@@ -660,7 +660,7 @@ describe('FiatConnect SDK', () => {
       )
       expect(response.isOk).toBeFalsy()
       expect(response.unwrap.bind(response)).toThrow(
-        new ResponseError('fake error message', undefined),
+        new ResponseError('fake error message'),
       )
     })
   })
@@ -720,7 +720,7 @@ describe('FiatConnect SDK', () => {
       const response = await client.transferIn(mockTransferRequestParams)
       expect(response.isOk).toBeFalsy()
       expect(response.unwrap.bind(response)).toThrow(
-        new ResponseError('fake error message', undefined),
+        new ResponseError('fake error message'),
       )
     })
   })
@@ -781,7 +781,7 @@ describe('FiatConnect SDK', () => {
       const response = await client.transferOut(mockTransferRequestParams)
       expect(response.isOk).toBeFalsy()
       expect(response.unwrap.bind(response)).toThrow(
-        new ResponseError('fake error message', undefined),
+        new ResponseError('fake error message'),
       )
     })
   })
@@ -824,7 +824,7 @@ describe('FiatConnect SDK', () => {
       )
       expect(response.isOk).toBeFalsy()
       expect(response.unwrap.bind(response)).toThrow(
-        new ResponseError('fake error message', undefined),
+        new ResponseError('fake error message'),
       )
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4825,11 +4825,6 @@ ts-jest@^27.1.3:
     semver "7.x"
     yargs-parser "20.x"
 
-ts-results@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/ts-results/-/ts-results-3.3.0.tgz#68623a6c18e65556287222dab76498a28154922f"
-  integrity sha512-FWqxGX2NHp5oCyaMd96o2y2uMQmSu8Dey6kvyuFdRJ2AzfmWo3kWa4UsPlCGlfQ/qu03m09ZZtppMoY8EMHuiA==
-
 tsconfig-paths@^3.14.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -281,6 +281,11 @@
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
+"@badrap/result@^0.2.12":
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/@badrap/result/-/result-0.2.12.tgz#ab5690ae04ee474ef6c912210b4126c56e7a0a9d"
+  integrity sha512-tSFeaiqM9p/2AtB0XNiTaZ0l+8icGxNTmF+v6sYBeV+JrFgoxhGn4BaM/SfP54Hc0eM3d8TwY0Q2k5AdSRaHIw==
+
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"


### PR DESCRIPTION
BREAKING CHANGE: Use of the new `Result` type implementation introduces changes to this package's API.

Fixes [this ticket](https://app.zenhub.com/workspaces/acquisition-squad-sprint-board-6010683afabec1001a090887/issues/valora-inc/in-house-liquidity/598).

Replaces the old [ts-results](https://github.com/vultix/ts-results) library with [@badrap/result](https://github.com/badrap/result).
This required a change in how we handle errors, since the new library requires that the "error" half of a `Result` type actually extends the `Error` built-in. All methods now return a `ResponseError` instance, which is a wrapper for general (non-FC) errors, as well as FC-specific error information, depending on the result of the API call.