### PR TITLE
chore(release): 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.2.2](https://github.com/fiatconnect/fiatconnect-sdk/compare/v0.2.1...v0.2.2) (2022-06-09)
+
+
+### Features
+
+* **result:** Replace Result implementation, simplify errors ([#24](https://github.com/fiatconnect/fiatconnect-sdk/issues/24)) ([0b1a154](https://github.com/fiatconnect/fiatconnect-sdk/commit/0b1a1549f0e7a895367c17683ceb62e4f5f49680))
+
 ### [0.2.1](https://github.com/fiatconnect/fiatconnect-sdk/compare/v0.2.0...v0.2.1) (2022-05-23)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiatconnect/fiatconnect-sdk",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A helper libary for wallets to integrate with FiatConnect APIs",
   "scripts": {
     "format": "prettier --loglevel error --write \"./**/*.ts\"",


### PR DESCRIPTION
Release the updated SDK. Still pre-v1.0.0, so we can do a non-major bump here.