### PR TITLE
fix(siwe): Convert account address to checksum address

### DIFF
--- a/src/fiat-connect-client.ts
+++ b/src/fiat-connect-client.ts
@@ -28,6 +28,7 @@ import {
   ClockDiffParams,
   ClockDiffResult,
 } from './types'
+import { ethers } from 'ethers'
 
 const NETWORK_CHAIN_IDS = {
   [Network.Alfajores]: 44787,
@@ -86,7 +87,10 @@ export class FiatConnectClient implements FiatConnectApiClient {
       const expirationDate = new Date(Date.now() + SESSION_DURATION_MS)
       const siweMessage = new SiweMessage({
         domain: new URL(this.config.baseUrl).hostname,
-        address: this.config.accountAddress,
+	// Some SIWE validators compare this against the checksummed signing address,
+	// and thus will always fail if this address is not checksummed. This coerces
+	// non-checksummed addresses to be checksummed.
+        address: ethers.utils.getAddress(this.config.accountAddress),
         statement: 'Sign in with Ethereum',
         uri: `${this.config.baseUrl}/auth/login`,
         version: '1',

--- a/src/fiat-connect-client.ts
+++ b/src/fiat-connect-client.ts
@@ -87,9 +87,9 @@ export class FiatConnectClient implements FiatConnectApiClient {
       const expirationDate = new Date(Date.now() + SESSION_DURATION_MS)
       const siweMessage = new SiweMessage({
         domain: new URL(this.config.baseUrl).hostname,
-	// Some SIWE validators compare this against the checksummed signing address,
-	// and thus will always fail if this address is not checksummed. This coerces
-	// non-checksummed addresses to be checksummed.
+        // Some SIWE validators compare this against the checksummed signing address,
+        // and thus will always fail if this address is not checksummed. This coerces
+        // non-checksummed addresses to be checksummed.
         address: ethers.utils.getAddress(this.config.accountAddress),
         statement: 'Sign in with Ethereum',
         uri: `${this.config.baseUrl}/auth/login`,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -38,7 +38,8 @@ describe('FiatConnect SDK', () => {
   const exampleIconUrl =
     'https://storage.googleapis.com/celo-mobile-mainnet.appspot.com/images/valora-icon.png'
   const exampleProviderName = 'Example Provider'
-  const accountAddress = '0x0D8e461687b7D06f86EC348E0c270b0F279855F0'
+  const accountAddress = '0x0d8e461687b7d06f86ec348e0c270b0f279855f0'
+  const checksummedAccountAddress = '0x0D8e461687b7D06f86EC348E0c270b0F279855F0'
   const signingFunction = jest.fn(() => Promise.resolve('signed message'))
   const client = new FiatConnectClient(
     {
@@ -160,7 +161,7 @@ describe('FiatConnect SDK', () => {
 
       const expectedSiweMessage = new siwe.SiweMessage({
         domain: 'fiat-connect-api.com',
-        address: accountAddress,
+        address: checksummedAccountAddress,
         statement: 'Sign in with Ethereum',
         uri: 'https://fiat-connect-api.com/auth/login',
         nonce: '12345678',
@@ -194,7 +195,7 @@ describe('FiatConnect SDK', () => {
 
       const expectedSiweMessage = new siwe.SiweMessage({
         domain: 'fiat-connect-api.com',
-        address: accountAddress,
+        address: checksummedAccountAddress,
         statement: 'Sign in with Ethereum',
         uri: 'https://fiat-connect-api.com/auth/login',
         nonce: '12345678',


### PR DESCRIPTION
The reference SIWE validation implementation used on the server-side compares the _checksummed account address_ used to sign the SIWE message against the _literal account address_ included within the SIWE message, using (presumably) simple string equality. This means that if the address included in the SIWE message is not checksummed, validation will _always fail_.

This PR converts the account address to a checksummed address before including it in the SIWE message. The FiatConnect specification actually requires that the [address be checksummed](https://github.com/fiatconnect/specification/blob/main/fiatconnect-api.md#3313-siwe-message-format), and it's [vaguely specified](https://eips.ethereum.org/EIPS/eip-4361) in the SIWE spec itself as well, so no changes are needed in the FC spec to enforce this.