### PR TITLE
feat(client): handle cookies based on platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "api",
     "celo"
   ],
-  "main": "dist/index.js",
+  "main": "dist/index-node.js",
+  "browser": "dist/index.js",
+  "react-native": "dist/index.js",
   "types": "dist/index.d.ts",
   "repository": "git@github.com:fiatconnect/fiatconnect-sdk.git",
   "author": "Jacob Waterman <jacob.waterman@valoraapp.com>",
@@ -50,9 +52,9 @@
   "dependencies": {
     "@badrap/result": "^0.2.12",
     "@fiatconnect/fiatconnect-types": "^6.0.0",
+    "cross-fetch": "^3.1.5",
     "ethers": "^5.6.4",
     "fetch-cookie": "^2.0.3",
-    "node-fetch": "^2.6.6",
     "siwe": "^1.1.6",
     "tslib": "^2.4.0"
   }

--- a/src/index-node.ts
+++ b/src/index-node.ts
@@ -1,6 +1,6 @@
+import 'cross-fetch/polyfill'
 import { FiatConnectClientImpl } from './fiat-connect-client'
 import { FiatConnectClientConfig } from './types'
-import fetch from 'cross-fetch'
 import fetchCookie from 'fetch-cookie'
 export * from './types'
 

--- a/src/index-node.ts
+++ b/src/index-node.ts
@@ -1,6 +1,7 @@
 import { FiatConnectClientImpl } from './fiat-connect-client'
 import { FiatConnectClientConfig } from './types'
 import fetch from 'cross-fetch'
+import fetchCookie from 'fetch-cookie'
 export * from './types'
 
 export class FiatConnectClient extends FiatConnectClientImpl {
@@ -8,6 +9,6 @@ export class FiatConnectClient extends FiatConnectClientImpl {
     config: FiatConnectClientConfig,
     signingFunction: (message: string) => Promise<string>,
   ) {
-    super(config, signingFunction, fetch)
+    super(config, signingFunction, fetchCookie(fetch))
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
+import 'cross-fetch/polyfill'
 import { FiatConnectClientImpl } from './fiat-connect-client'
 import { FiatConnectClientConfig } from './types'
-import fetch from 'cross-fetch'
 export * from './types'
 
 export class FiatConnectClient extends FiatConnectClientImpl {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -34,6 +34,8 @@ jest.mock('siwe', () => ({
   ...jest.requireActual('siwe'),
 }))
 
+// jest.mock('cross-fetch')
+
 describe('FiatConnect SDK', () => {
   const accountAddress = '0x0d8e461687b7d06f86ec348e0c270b0f279855f0'
   const checksummedAccountAddress = '0x0D8e461687b7D06f86EC348E0c270b0F279855F0'
@@ -54,24 +56,6 @@ describe('FiatConnect SDK', () => {
     getHeadersMock.mockReset()
     jest.clearAllMocks()
     client._sessionExpiry = undefined
-  })
-  describe('constructor', () => {
-    it('uses default fetch implementation if fetchImpl param is not set', () => {
-      expect(client.fetchImpl).toBeDefined()
-    })
-    it('uses custom fetch implementation', () => {
-      const customFetch = jest.fn()
-      const fcClient = new FiatConnectClient(
-        {
-          baseUrl: 'https://fiat-connect-api.com',
-          network: Network.Alfajores,
-          accountAddress,
-        },
-        signingFunction,
-        customFetch,
-      )
-      expect(fcClient.fetchImpl).toEqual(customFetch)
-    })
   })
   describe('getClock', () => {
     it('gets the server clock', async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -55,6 +55,24 @@ describe('FiatConnect SDK', () => {
     jest.clearAllMocks()
     client._sessionExpiry = undefined
   })
+  describe('constructor', () => {
+    it('uses default fetch implementation if fetchImpl param is not set', () => {
+      expect(client.fetchImpl).toBeDefined()
+    })
+    it('uses custom fetch implementation', () => {
+      const customFetch = jest.fn()
+      const fcClient = new FiatConnectClient(
+        {
+          baseUrl: 'https://fiat-connect-api.com',
+          network: Network.Alfajores,
+          accountAddress,
+        },
+        signingFunction,
+        customFetch,
+      )
+      expect(fcClient.fetchImpl).toEqual(customFetch)
+    })
+  })
   describe('getClock', () => {
     it('gets the server clock', async () => {
       fetchMock.mockResponseOnce(JSON.stringify(mockClockResponse))

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -34,8 +34,6 @@ jest.mock('siwe', () => ({
   ...jest.requireActual('siwe'),
 }))
 
-// jest.mock('cross-fetch')
-
 describe('FiatConnect SDK', () => {
   const accountAddress = '0x0d8e461687b7d06f86ec348e0c270b0f279855f0'
   const checksummedAccountAddress = '0x0D8e461687b7D06f86EC348E0c270b0F279855F0'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1847,7 +1847,7 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cross-fetch@^3.0.4:
+cross-fetch@^3.0.4, cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==


### PR DESCRIPTION
React native does cookie handling by default, and is not working well with the fetch-cookie implementation on iOS (the cookie is appended twice on iOS with `,` separator which the server recognizes as a single cookie). This updates the SDK to automatically use the `fetchCookie` wrapper on envs that don't handle cookies.