### PR TITLE
feat(cookie): add cookie handling to pass auth session cookie to IHL

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,10 +52,12 @@
   "dependencies": {
     "@badrap/result": "^0.2.12",
     "@fiatconnect/fiatconnect-types": "^7.0.0",
+    "@types/tough-cookie": "^4.0.2",
     "cross-fetch": "^3.1.5",
     "ethers": "^5.6.4",
     "fetch-cookie": "^2.0.3",
     "siwe": "^1.1.6",
+    "tough-cookie": "^4.0.0",
     "tslib": "^2.4.0"
   }
 }

--- a/src/index-node.ts
+++ b/src/index-node.ts
@@ -1,14 +1,56 @@
 import 'cross-fetch/polyfill'
 import { FiatConnectClientImpl } from './fiat-connect-client'
-import { FiatConnectClientConfig } from './types'
-import fetchCookie from 'fetch-cookie'
-export * from './types'
+import { AddKycParams, FiatConnectClientConfig, ResponseError } from './types'
+import makeFetchCookie from 'fetch-cookie'
+import { CookieJar } from 'tough-cookie'
+import { KycSchema, KycStatusResponse } from '@fiatconnect/fiatconnect-types'
+import { Result } from '@badrap/result'
+import { handleError } from './fiat-connect-client'
 
 export class FiatConnectClient extends FiatConnectClientImpl {
   constructor(
     config: FiatConnectClientConfig,
     signingFunction: (message: string) => Promise<string>,
+    cookieJar?: CookieJar.Serialized,
   ) {
-    super(config, signingFunction, fetchCookie(fetch))
+    if (cookieJar) {
+      super(
+        config,
+        signingFunction,
+        makeFetchCookie(fetch, CookieJar.deserializeSync(cookieJar)),
+        cookieJar,
+      )
+    } else {
+      super(config, signingFunction, makeFetchCookie(fetch))
+    }
+  }
+
+  /**
+   * https://github.com/fiatconnect/specification/blob/main/fiatconnect-api.md#3421-post-kyckycschema
+   * Same as implementation in fiat-connect-client.ts except check for _ensureLogin
+   */
+  async addKyc<T extends KycSchema>(
+    params: AddKycParams<T>,
+  ): Promise<Result<KycStatusResponse, ResponseError>> {
+    try {
+      const response = await this.fetchImpl(
+        `${this.config.baseUrl}/kyc/${params.kycSchemaName}`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...this._getAuthHeader(),
+          },
+          body: JSON.stringify(params.data),
+        },
+      )
+      const data = await response.json()
+      if (!response.ok) {
+        return handleError(data)
+      }
+      return Result.ok(data)
+    } catch (error) {
+      return handleError(error)
+    }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,6 @@ import {
   FiatAccountSchema,
 } from '@fiatconnect/fiatconnect-types'
 import { Result } from '@badrap/result'
-import { CookieJar } from 'tough-cookie'
 
 export interface FiatConnectApiClient {
   getServerTimeApprox(): Promise<Result<Date, ResponseError>>
@@ -116,9 +115,4 @@ export class ResponseError extends Error {
     this.minimumCryptoAmount = data?.minimumCryptoAmount
     this.maximumCryptoAmount = data?.maximumCryptoAmount
   }
-}
-
-export type SetCookiesParams = {
-  cookies: CookieJar
-  baseUrl: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ import {
   FiatAccountSchema,
 } from '@fiatconnect/fiatconnect-types'
 import { Result } from '@badrap/result'
+import { CookieJar } from 'tough-cookie'
 
 export interface FiatConnectApiClient {
   getServerTimeApprox(): Promise<Result<Date, ResponseError>>
@@ -115,4 +116,9 @@ export class ResponseError extends Error {
     this.minimumCryptoAmount = data?.minimumCryptoAmount
     this.maximumCryptoAmount = data?.maximumCryptoAmount
   }
+}
+
+export type SetCookiesParams = {
+  cookies: CookieJar
+  baseUrl: string
 }

--- a/test/index-node.test.ts
+++ b/test/index-node.test.ts
@@ -1,0 +1,57 @@
+import { FiatConnectClient } from '../src/index-node'
+import { KycSchema, Network } from '@fiatconnect/fiatconnect-types'
+import { CookieJar } from 'tough-cookie'
+import { mockKycSchemaData, mockKycStatusResponse } from './mocks'
+import 'jest-fetch-mock'
+
+describe('FiatConnect Node SDK', () => {
+  const accountAddress = '0x0d8e461687b7d06f86ec348e0c270b0f279855f0'
+  const signingFunction = jest.fn(() => Promise.resolve('signed message'))
+  const mockCookieJar = new CookieJar()
+  mockCookieJar.setCookie('session=session-val', 'https://fiat-connect-api.com')
+  const client = new FiatConnectClient(
+    {
+      baseUrl: 'https://fiat-connect-api.com',
+      network: Network.Alfajores,
+      accountAddress,
+    },
+    signingFunction,
+    mockCookieJar.serializeSync(),
+  )
+  const getHeadersMock = jest.spyOn(client, '_getAuthHeader')
+
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2022-05-01T00:00:00Z'))
+    fetchMock.resetMocks()
+    jest.clearAllMocks()
+    client._sessionExpiry = undefined
+  })
+  describe('cookie handling', () => {
+    it('inject cookie jar into client', async () => {
+      const cookieJar = await client.getCookieJar()
+      expect(cookieJar.cookies.length).toBe(1)
+      expect(cookieJar.cookies[0].key).toBe('session')
+      expect(cookieJar.cookies[0].value).toBe('session-val')
+    })
+    it('should include session cookies in add kyc call', async () => {
+      fetchMock.mockResponseOnce(JSON.stringify(mockKycStatusResponse))
+      const response = await client.addKyc({
+        kycSchemaName: KycSchema.PersonalDataAndDocuments,
+        data: mockKycSchemaData,
+      })
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://fiat-connect-api.com/kyc/PersonalDataAndDocuments',
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            cookie: 'session=session-val',
+          },
+        }),
+      )
+      expect(response.isOk).toBeTruthy()
+      expect(response.unwrap()).toMatchObject(mockKycStatusResponse)
+      expect(getHeadersMock).toHaveBeenCalled()
+    })
+  })
+})

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -25,8 +25,6 @@ import {
 } from '@fiatconnect/fiatconnect-types'
 import * as siwe from 'siwe'
 import { Result } from '@badrap/result'
-import { CookieJar } from 'tough-cookie'
-import { Headers } from 'node-fetch'
 
 // work around from
 // https://github.com/aelbore/esbuild-jest/issues/26#issuecomment-968853688 for
@@ -954,92 +952,9 @@ describe('FiatConnect SDK', () => {
       })
 
       const cookieJar = await client.getCookieJar()
-      const cookies = cookieJar.getCookiesSync('https://fiat-connect-api.com')
-      expect(cookies.length).toBe(1)
-      expect(cookies[0].key).toBe('session')
-      expect(cookies[0].value).toBe('session-val')
-    })
-    it('setCookies', async () => {
-      const ihlClient = new FiatConnectClient(
-        {
-          baseUrl: 'https://in-house-liquidity-api.com',
-          network: Network.Alfajores,
-          accountAddress: '0x0d8e461687b7d06f86ec348e0c270b0f279855f1', // changed last digit from 0 to 1
-        },
-        signingFunction,
-      )
-      const mockCookies = new CookieJar()
-      mockCookies.setCookie(
-        'session=session-val',
-        'https://fiat-connect-api.com',
-      )
-
-      await ihlClient.setCookieJar({
-        cookies: mockCookies,
-        baseUrl: 'https://fiat-connect-api.com',
-      })
-      const ihlCookieJar = await ihlClient.getCookieJar()
-      const ihlCookies = await ihlCookieJar.getCookies(
-        'https://in-house-liquidity-api.com',
-      )
-      expect(ihlCookies.length).toBe(1)
-      expect(ihlCookies[0].key).toBe('session')
-      expect(ihlCookies[0].value).toBe('session-val')
-    })
-    it('transfer cookies from one client to another', async () => {
-      jest.spyOn(siwe, 'generateNonce').mockReturnValueOnce('12345678')
-      fetchMock.mockResponseOnce('', {
-        headers: { 'set-cookie': 'session=session-val' },
-      })
-
-      await client.login({
-        issuedAt: new Date('2022-10-02T10:01:56+0000'),
-      })
-
-      const ihlClient = new FiatConnectClient(
-        {
-          baseUrl: 'https://in-house-liquidity-api.com',
-          network: Network.Alfajores,
-          accountAddress: '0x0d8e461687b7d06f86ec348e0c270b0f279855f1', // changed last digit from 0 to 1
-        },
-        signingFunction,
-      )
-
-      await ihlClient.setCookieJar({
-        cookies: await client.getCookieJar(),
-        baseUrl: 'https://fiat-connect-api.com',
-      })
-      const ihlCookieJar = await ihlClient.getCookieJar()
-      const ihlCookies = await ihlCookieJar.getCookies(
-        'https://in-house-liquidity-api.com',
-      )
-      expect(ihlCookies.length).toBe(1)
-      expect(ihlCookies[0].key).toBe('session')
-      expect(ihlCookies[0].value).toBe('session-val')
-    })
-    it('_addCookiesToHeader', async () => {
-      const ihlClient = new FiatConnectClient(
-        {
-          baseUrl: 'https://in-house-liquidity-api.com',
-          network: Network.Alfajores,
-          accountAddress: '0x0d8e461687b7d06f86ec348e0c270b0f279855f1', // changed last digit from 0 to 1
-        },
-        signingFunction,
-      )
-      const mockCookies = new CookieJar()
-      mockCookies.setCookie(
-        'session=session-val',
-        'https://fiat-connect-api.com',
-      )
-
-      await ihlClient.setCookieJar({
-        cookies: mockCookies,
-        baseUrl: 'https://fiat-connect-api.com',
-      })
-
-      const header = new Headers()
-      await ihlClient._addCookiesToHeader(header)
-      expect(await header.get('cookie')).toBe('session=session-val')
+      expect(cookieJar.cookies.length).toBe(1)
+      expect(cookieJar.cookies[0].key).toBe('session')
+      expect(cookieJar.cookies[0].value).toBe('session-val')
     })
   })
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -953,10 +953,11 @@ describe('FiatConnect SDK', () => {
         issuedAt: new Date('2022-10-02T10:01:56+0000'),
       })
 
-      const cookies = await client.getCookieJar()
-      expect(
-        cookies.getCookiesSync('https://fiat-connect-api.com').length,
-      ).toBe(1)
+      const cookieJar = await client.getCookieJar()
+      const cookies = cookieJar.getCookiesSync('https://fiat-connect-api.com')
+      expect(cookies.length).toBe(1)
+      expect(cookies[0].key).toBe('session')
+      expect(cookies[0].value).toBe('session-val')
     })
     it('setCookies', async () => {
       const ihlClient = new FiatConnectClient(
@@ -978,10 +979,12 @@ describe('FiatConnect SDK', () => {
         baseUrl: 'https://fiat-connect-api.com',
       })
       const ihlCookieJar = await ihlClient.getCookieJar()
-      expect(
-        ihlCookieJar.getCookiesSync('https://in-house-liquidity-api.com')
-          .length,
-      ).toBe(1)
+      const ihlCookies = await ihlCookieJar.getCookies(
+        'https://in-house-liquidity-api.com',
+      )
+      expect(ihlCookies.length).toBe(1)
+      expect(ihlCookies[0].key).toBe('session')
+      expect(ihlCookies[0].value).toBe('session-val')
     })
     it('transfer cookies from one client to another', async () => {
       jest.spyOn(siwe, 'generateNonce').mockReturnValueOnce('12345678')
@@ -1007,10 +1010,12 @@ describe('FiatConnect SDK', () => {
         baseUrl: 'https://fiat-connect-api.com',
       })
       const ihlCookieJar = await ihlClient.getCookieJar()
-      expect(
-        ihlCookieJar.getCookiesSync('https://in-house-liquidity-api.com')
-          .length,
-      ).toBe(1)
+      const ihlCookies = await ihlCookieJar.getCookies(
+        'https://in-house-liquidity-api.com',
+      )
+      expect(ihlCookies.length).toBe(1)
+      expect(ihlCookies[0].key).toBe('session')
+      expect(ihlCookies[0].value).toBe('session-val')
     })
     it('_addCookiesToHeader', async () => {
       const ihlClient = new FiatConnectClient(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1081,6 +1081,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
+"@types/tough-cookie@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
+  integrity sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==
+
 "@types/uuid@^8.3.4":
   version "8.3.4"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"


### PR DESCRIPTION
Added getter and setter methods to SDK client to manipulate all cookies. 
Added helper method to apply cookies to a header object.

When a client consumes a cookie, its domain is changed to the current client's base url. 