### PR TITLE
fix(cookies): reverted node's getter back to raw()

### DIFF
--- a/src/index-node.ts
+++ b/src/index-node.ts
@@ -28,10 +28,19 @@ export class SiweClient extends SiweImpl {
 
   async _extractCookies(headers?: Headers): Promise<void> {
     const cookieRecord: Record<string, string> = {}
-    const setCookie = Cookie.parse(headers?.get('set-cookie') || '')
-    if (setCookie) {
-      cookieRecord[setCookie.key] = setCookie.value
+    const headerSetCookies = (headers as any).raw()[
+      'set-cookie'
+    ] as Array<string>
+
+    if (headerSetCookies) {
+      headerSetCookies.forEach(async (cookieString: string) => {
+        const setCookie = Cookie.parse(cookieString)
+        if (setCookie) {
+          cookieRecord[setCookie.key] = setCookie.value
+        }
+      })
     }
+
     this._cookieJar = cookieRecord
   }
 }

--- a/test/index-node.test.ts
+++ b/test/index-node.test.ts
@@ -69,6 +69,18 @@ describe('FiatConnect SDK node', () => {
       expect(client.fetchImpl.name).toEqual('fetchCookieWrapper')
     })
 
+    describe('_extractCookies', () => {
+      it('parses header for cookies', async () => {
+        const mockheader: Headers = new Headers({
+          'set-cookie': 'session=session-val',
+        })
+
+        await client._extractCookies(mockheader)
+
+        expect(client._cookieJar).toStrictEqual({ session: 'session-val' })
+      })
+    })
+
     describe('getCookies', () => {
       it('returns serialized cookies from login', async () => {
         jest.spyOn(siwe, 'generateNonce').mockReturnValueOnce('12345678')

--- a/test/index-node.test.ts
+++ b/test/index-node.test.ts
@@ -71,13 +71,18 @@ describe('FiatConnect SDK node', () => {
 
     describe('_extractCookies', () => {
       it('parses header for cookies', async () => {
-        const mockheader: Headers = new Headers({
-          'set-cookie': 'session=session-val',
+        const mockHeader = {
+          raw: () => ({
+            'set-cookie': ['session=session-val', 'session2=session-val2'],
+          }),
+        } as any as Headers
+
+        await client._extractCookies(mockHeader)
+
+        expect(client._cookieJar).toStrictEqual({
+          session: 'session-val',
+          session2: 'session-val2',
         })
-
-        await client._extractCookies(mockheader)
-
-        expect(client._cookieJar).toStrictEqual({ session: 'session-val' })
       })
     })
 


### PR DESCRIPTION
In the case that multiple set-cookie headers are received, the old implementation of headers.get('set-cookie') would return a string sequence, making parsing difficult. Using .raw() returns an array of strings, making parsing easier.