### PR TITLE
fix(siwe-client): make headers a constructor param

### DIFF
--- a/src/fiat-connect-client.ts
+++ b/src/fiat-connect-client.ts
@@ -443,7 +443,7 @@ export function createSiweConfig(
   }
 }
 
-export function _getAuthHeader(apiKey?: string) {
+function _getAuthHeader(apiKey?: string) {
   if (apiKey) {
     return { Authorization: `Bearer ${apiKey}` }
   }

--- a/src/fiat-connect-client.ts
+++ b/src/fiat-connect-client.ts
@@ -51,12 +51,6 @@ export class FiatConnectClientImpl implements FiatConnectApiClient {
     this.fetchImpl = fetchImpl
   }
 
-  _getAuthHeader() {
-    if (this.config.apiKey) {
-      return { Authorization: `Bearer ${this.config.apiKey}` }
-    }
-  }
-
   /**
    * Checks if a logged in session exists with the provider.
    *
@@ -77,7 +71,6 @@ export class FiatConnectClientImpl implements FiatConnectApiClient {
     try {
       await this._siweClient.login({
         issuedAt: params?.issuedAt,
-        headers: this._getAuthHeader(),
       })
 
       return Result.ok('success')
@@ -97,7 +90,7 @@ export class FiatConnectClientImpl implements FiatConnectApiClient {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            ...this._getAuthHeader(),
+            ..._getAuthHeader(this.config.apiKey),
           },
           body: JSON.stringify(body),
         },
@@ -182,7 +175,7 @@ export class FiatConnectClientImpl implements FiatConnectApiClient {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            ...this._getAuthHeader(),
+            ..._getAuthHeader(this.config.apiKey),
           },
           body: JSON.stringify(params.data),
         },
@@ -208,7 +201,7 @@ export class FiatConnectClientImpl implements FiatConnectApiClient {
         `${this.config.baseUrl}/kyc/${params.kycSchema}`,
         {
           method: 'DELETE',
-          headers: this._getAuthHeader(),
+          headers: _getAuthHeader(this.config.apiKey),
         },
       )
       const data = await response.json()
@@ -232,7 +225,7 @@ export class FiatConnectClientImpl implements FiatConnectApiClient {
         `${this.config.baseUrl}/kyc/${params.kycSchema}/status`,
         {
           method: 'GET',
-          headers: this._getAuthHeader(),
+          headers: _getAuthHeader(this.config.apiKey),
         },
       )
       const data = await response.json()
@@ -258,7 +251,7 @@ export class FiatConnectClientImpl implements FiatConnectApiClient {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            ...this._getAuthHeader(),
+            ..._getAuthHeader(this.config.apiKey),
           },
           body: JSON.stringify(params),
         },
@@ -284,7 +277,7 @@ export class FiatConnectClientImpl implements FiatConnectApiClient {
         `${this.config.baseUrl}/accounts`,
         {
           method: 'GET',
-          headers: this._getAuthHeader(),
+          headers: _getAuthHeader(this.config.apiKey),
         },
       )
       const data = await response.json()
@@ -308,7 +301,7 @@ export class FiatConnectClientImpl implements FiatConnectApiClient {
         `${this.config.baseUrl}/accounts/${params.fiatAccountId}`,
         {
           method: 'DELETE',
-          headers: this._getAuthHeader(),
+          headers: _getAuthHeader(this.config.apiKey),
         },
       )
       const data = await response.json()
@@ -335,7 +328,7 @@ export class FiatConnectClientImpl implements FiatConnectApiClient {
           headers: {
             'Content-Type': 'application/json',
             'Idempotency-Key': params.idempotencyKey,
-            ...this._getAuthHeader(),
+            ..._getAuthHeader(this.config.apiKey),
           },
           body: JSON.stringify(params.data),
         },
@@ -364,7 +357,7 @@ export class FiatConnectClientImpl implements FiatConnectApiClient {
           headers: {
             'Content-Type': 'application/json',
             'Idempotency-Key': params.idempotencyKey,
-            ...this._getAuthHeader(),
+            ..._getAuthHeader(this.config.apiKey),
           },
           body: JSON.stringify(params.data),
         },
@@ -390,7 +383,7 @@ export class FiatConnectClientImpl implements FiatConnectApiClient {
         `${this.config.baseUrl}/transfer/${params.transferId}/status`,
         {
           method: 'GET',
-          headers: this._getAuthHeader(),
+          headers: _getAuthHeader(this.config.apiKey),
         },
       )
       const data = await response.json()
@@ -446,5 +439,12 @@ export function createSiweConfig(
     sessionDurationMs: SESSION_DURATION_MS,
     loginUrl: `${config.baseUrl}/auth/login`,
     clockUrl: `${config.baseUrl}/clock`,
+    loginHeaders: _getAuthHeader(config.apiKey),
+  }
+}
+
+export function _getAuthHeader(apiKey?: string) {
+  if (apiKey) {
+    return { Authorization: `Bearer ${apiKey}` }
   }
 }

--- a/src/fiat-connect-client.ts
+++ b/src/fiat-connect-client.ts
@@ -439,7 +439,7 @@ export function createSiweConfig(
     sessionDurationMs: SESSION_DURATION_MS,
     loginUrl: `${config.baseUrl}/auth/login`,
     clockUrl: `${config.baseUrl}/clock`,
-    loginHeaders: _getAuthHeader(config.apiKey),
+    headers: _getAuthHeader(config.apiKey),
   }
 }
 

--- a/src/siwe-client.ts
+++ b/src/siwe-client.ts
@@ -4,9 +4,9 @@ import { generateNonce, SiweMessage } from 'siwe'
 import {
   ClockDiffParams,
   ClockDiffResult,
+  LoginParams,
   SiweApiClient,
   SiweClientConfig,
-  SiweLoginParams,
 } from './types'
 
 export abstract class SiweImpl implements SiweApiClient {
@@ -30,9 +30,9 @@ export abstract class SiweImpl implements SiweApiClient {
   /**
    * Logs in with the SIWE compliant API and initializes a session.
    *
-   * @param {SiweLoginParams} params optional object containing params used to log in
+   * @param {LoginParams} params optional object containing params used to log in
    */
-  async login(params?: SiweLoginParams): Promise<void> {
+  async login(params?: LoginParams): Promise<void> {
     // Prefer param issued-at > diff-based issued-at > client-based issued-at
     let issuedAt = params?.issuedAt
     if (!issuedAt) {
@@ -72,8 +72,8 @@ export abstract class SiweImpl implements SiweApiClient {
     const response = await this.fetchImpl(this.config.loginUrl, {
       method: 'POST',
       headers: {
+        ...this.config.loginHeaders,
         'Content-Type': 'application/json',
-        ...params?.headers,
       },
       body: JSON.stringify(body),
     })

--- a/src/siwe-client.ts
+++ b/src/siwe-client.ts
@@ -72,7 +72,7 @@ export abstract class SiweImpl implements SiweApiClient {
     const response = await this.fetchImpl(this.config.loginUrl, {
       method: 'POST',
       headers: {
-        ...this.config.loginHeaders,
+        ...this.config.headers,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(body),
@@ -112,7 +112,9 @@ export abstract class SiweImpl implements SiweApiClient {
    * 8601 datetime string.
    */
   async getClock(): Promise<ClockResponse> {
-    const response = await this.fetchImpl(`${this.config.clockUrl}`)
+    const response = await this.fetchImpl(this.config.clockUrl, {
+      headers: this.config.headers,
+    })
     if (!response.ok) {
       const responseText = await response.text()
       throw new Error(
@@ -165,7 +167,9 @@ export abstract class SiweImpl implements SiweApiClient {
 
   /**
    * A wrapper around fetch that ensures a session exists before making the
-   * fetch request
+   * fetch request. This has the same API as the fetch API. It ignores headers
+   * set in the config of the constructor and passes fetch options as is, so any
+   * required header MUST be set in the options.
    *
    * @param input the fetch input
    * @param init the fetch options

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export interface SiweApiClient {
   getServerTimeApprox(): Promise<Date>
   getClockDiffApprox(): Promise<ClockDiffResult>
   getClock(): Promise<ClockResponse>
-  login(params?: SiweLoginParams): Promise<void>
+  login(params?: LoginParams): Promise<void>
   isLoggedIn(): boolean
   fetch: typeof fetch
   getCookies(): Record<string, string>
@@ -77,14 +77,11 @@ export interface SiweClientConfig {
   sessionDurationMs: number
   loginUrl: string
   clockUrl: string
+  loginHeaders?: HeadersInit
 }
 
 export interface LoginParams {
   issuedAt?: Date
-}
-
-export type SiweLoginParams = LoginParams & {
-  headers?: Record<string, string>
 }
 
 export interface AddKycParams<T extends KycSchema> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,7 +77,7 @@ export interface SiweClientConfig {
   sessionDurationMs: number
   loginUrl: string
   clockUrl: string
-  loginHeaders?: HeadersInit
+  headers?: HeadersInit
 }
 
 export interface LoginParams {

--- a/test/fiat-connect-client.test.ts
+++ b/test/fiat-connect-client.test.ts
@@ -713,7 +713,7 @@ describe('createSiweConfig', () => {
       sessionDurationMs: 14400000,
       loginUrl: 'https://fiat-connect-api.com/auth/login',
       clockUrl: 'https://fiat-connect-api.com/clock',
-      loginHeaders: undefined,
+      headers: undefined,
     })
   })
 
@@ -733,7 +733,7 @@ describe('createSiweConfig', () => {
       sessionDurationMs: 14400000,
       loginUrl: 'https://fiat-connect-api.com/auth/login',
       clockUrl: 'https://fiat-connect-api.com/clock',
-      loginHeaders: { Authorization: 'Bearer token' },
+      headers: { Authorization: 'Bearer token' },
     })
   })
 })

--- a/test/index-browser.test.ts
+++ b/test/index-browser.test.ts
@@ -27,7 +27,7 @@ describe('FiatConnect SDK browser', () => {
         sessionDurationMs: 14400000,
         statement: 'Sign in with Ethereum',
         version: '1',
-        loginHeaders: undefined,
+        headers: undefined,
       })
     })
   })

--- a/test/index-browser.test.ts
+++ b/test/index-browser.test.ts
@@ -27,6 +27,7 @@ describe('FiatConnect SDK browser', () => {
         sessionDurationMs: 14400000,
         statement: 'Sign in with Ethereum',
         version: '1',
+        loginHeaders: undefined,
       })
     })
   })

--- a/test/index-node.test.ts
+++ b/test/index-node.test.ts
@@ -39,6 +39,7 @@ describe('FiatConnect SDK node', () => {
         sessionDurationMs: 14400000,
         statement: 'Sign in with Ethereum',
         version: '1',
+        loginHeaders: undefined,
       })
     })
   })

--- a/test/index-react-native.test.ts
+++ b/test/index-react-native.test.ts
@@ -53,7 +53,7 @@ describe('FiatConnect SDK react-native', () => {
         sessionDurationMs: 14400000,
         statement: 'Sign in with Ethereum',
         version: '1',
-        loginHeaders: undefined,
+        headers: undefined,
       })
     })
   })

--- a/test/index-react-native.test.ts
+++ b/test/index-react-native.test.ts
@@ -53,6 +53,7 @@ describe('FiatConnect SDK react-native', () => {
         sessionDurationMs: 14400000,
         statement: 'Sign in with Ethereum',
         version: '1',
+        loginHeaders: undefined,
       })
     })
   })

--- a/test/siwe-client.test.ts
+++ b/test/siwe-client.test.ts
@@ -61,7 +61,9 @@ describe('SIWE client', () => {
     it('gets the server clock', async () => {
       fetchMock.mockResponseOnce(JSON.stringify(mockClockResponse))
       const response = await client.getClock()
-      expect(fetchMock).toHaveBeenCalledWith('https://siwe-api.com/clock')
+      expect(fetchMock).toHaveBeenCalledWith('https://siwe-api.com/clock', {
+        headers: undefined,
+      })
       expect(response).toMatchObject(mockClockResponse)
     })
     it('handles error responses', async () => {

--- a/test/siwe-client.test.ts
+++ b/test/siwe-client.test.ts
@@ -35,7 +35,7 @@ describe('SIWE client', () => {
     signingFunction,
     fetch,
   )
-  const clientWithLoginHeaders = new TestSiweClient(
+  const clientWithHeaders = new TestSiweClient(
     {
       accountAddress,
       statement: 'Sign in with Ethereum',
@@ -44,7 +44,7 @@ describe('SIWE client', () => {
       sessionDurationMs: 3600000,
       loginUrl: 'https://siwe-api.com/login',
       clockUrl: 'https://siwe-api.com/clock',
-      loginHeaders: { Authorization: 'Bearer token' },
+      headers: { Authorization: 'Bearer token' },
     },
     signingFunction,
     fetch,
@@ -176,7 +176,7 @@ describe('SIWE client', () => {
         headers: { 'set-cookie': 'session=session-val' },
       })
 
-      await clientWithLoginHeaders.login({
+      await clientWithHeaders.login({
         issuedAt: new Date('2022-10-02T10:01:56+0000'),
       })
 

--- a/test/siwe-client.test.ts
+++ b/test/siwe-client.test.ts
@@ -35,6 +35,20 @@ describe('SIWE client', () => {
     signingFunction,
     fetch,
   )
+  const clientWithLoginHeaders = new TestSiweClient(
+    {
+      accountAddress,
+      statement: 'Sign in with Ethereum',
+      chainId: 1,
+      version: '1',
+      sessionDurationMs: 3600000,
+      loginUrl: 'https://siwe-api.com/login',
+      clockUrl: 'https://siwe-api.com/clock',
+      loginHeaders: { Authorization: 'Bearer token' },
+    },
+    signingFunction,
+    fetch,
+  )
 
   beforeEach(() => {
     jest.useFakeTimers().setSystemTime(new Date('2022-05-01T00:00:00Z'))
@@ -162,9 +176,8 @@ describe('SIWE client', () => {
         headers: { 'set-cookie': 'session=session-val' },
       })
 
-      await client.login({
+      await clientWithLoginHeaders.login({
         issuedAt: new Date('2022-10-02T10:01:56+0000'),
-        headers: { Authorization: 'Bearer token' },
       })
 
       const expectedSiweMessage = new siwe.SiweMessage({


### PR DESCRIPTION
This allows login from the fetch method to also pass the login header