### PR TITLE
feat(types): Update transfer endpoint types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiatconnect/fiatconnect-sdk",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "A helper library for wallets to integrate with FiatConnect APIs",
   "scripts": {
     "format": "prettier --loglevel error --write \"./**/*.ts\"",

--- a/src/fiat-connect-client.ts
+++ b/src/fiat-connect-client.ts
@@ -9,7 +9,8 @@ import {
   QuoteErrorResponse,
   QuoteRequestBody,
   QuoteResponse,
-  TransferResponse,
+  TransferInResponse,
+  TransferOutResponse,
   TransferStatusRequestParams,
   TransferStatusResponse,
   ClockResponse,
@@ -370,7 +371,7 @@ export class FiatConnectClientImpl implements FiatConnectApiClient {
    */
   async transferIn(
     params: TransferRequestParams,
-  ): Promise<Result<TransferResponse, ResponseError>> {
+  ): Promise<Result<TransferInResponse, ResponseError>> {
     try {
       const response = await this._siweClient.fetch(
         `${this.config.baseUrl}/transfer/in`,
@@ -400,7 +401,7 @@ export class FiatConnectClientImpl implements FiatConnectApiClient {
    */
   async transferOut(
     params: TransferRequestParams,
-  ): Promise<Result<TransferResponse, ResponseError>> {
+  ): Promise<Result<TransferOutResponse, ResponseError>> {
     try {
       const response = await this._siweClient.fetch(
         `${this.config.baseUrl}/transfer/out`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,8 @@ import {
   QuoteRequestBody,
   QuoteResponse,
   TransferRequestBody,
-  TransferResponse,
+  TransferInResponse,
+  TransferOutResponse,
   TransferStatusRequestParams,
   TransferStatusResponse,
   ClockResponse,
@@ -66,10 +67,10 @@ export interface FiatConnectApiClient {
   ): Promise<Result<void, ResponseError>>
   transferIn(
     params: TransferRequestParams,
-  ): Promise<Result<TransferResponse, ResponseError>>
+  ): Promise<Result<TransferInResponse, ResponseError>>
   transferOut(
     params: TransferRequestParams,
-  ): Promise<Result<TransferResponse, ResponseError>>
+  ): Promise<Result<TransferOutResponse, ResponseError>>
   getTransferStatus(
     params: TransferStatusRequestParams,
   ): Promise<Result<TransferStatusResponse, ResponseError>>


### PR DESCRIPTION
As is, the types used for the transfer methods on the FC client were _not_ allowing `userActionDetails` to be accessed fromt he result of calling `client.transferIn`. This update fixes the types to allow it to be accessed. I'm not sure whether this should be considered backwards compatible or not. While the changes to the types themselves are backwards compatible (only new fields added, no existing ones removed), clients could be using the types in such a way that it would cause their build to break/TS errors if they bumped the version.