### PR TITLE
chore(release): 0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [0.5.5](https://github.com/fiatconnect/fiatconnect-sdk/compare/v0.5.3...v0.5.5) (2023-07-07)
+### [0.5.4](https://github.com/fiatconnect/fiatconnect-sdk/compare/v0.5.3...v0.5.4) (2023-07-07)
 
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.5.5](https://github.com/fiatconnect/fiatconnect-sdk/compare/v0.5.3...v0.5.5) (2023-07-07)
+
+
+### Features
+
+* **types:** Update transfer endpoint types ([#170](https://github.com/fiatconnect/fiatconnect-sdk/issues/170)) ([3432c31](https://github.com/fiatconnect/fiatconnect-sdk/commit/3432c31c8e4d58dde36127cf736af98e51835e03))
+
 ### [0.5.3](https://github.com/fiatconnect/fiatconnect-sdk/compare/v0.5.2...v0.5.3) (2023-06-27)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiatconnect/fiatconnect-sdk",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "A helper library for wallets to integrate with FiatConnect APIs",
   "scripts": {
     "format": "prettier --loglevel error --write \"./**/*.ts\"",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiatconnect/fiatconnect-sdk",
-  "version": "0.5.5",
+  "version": "0.5.4",
   "description": "A helper library for wallets to integrate with FiatConnect APIs",
   "scripts": {
     "format": "prettier --loglevel error --write \"./**/*.ts\"",


### PR DESCRIPTION
[ticket for publishing fiatconnect-sdk as part of cicd](https://linear.app/valora/issue/ACT-853/publish-fiatconnect-sdk-as-part-of-cicd)