### PR TITLE
chore(deps): migrate `@react-native-cookies/cookies` to `@divvi/cookies`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "typescript.tsdk": "node_modules/typescript/lib"
-}

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "typescript": "^5.7.3"
   },
   "peerDependencies": {
-    "@react-native-cookies/cookies": "^6.2.1"
+    "@divvi/cookies": "^6.2.1"
   },
   "peerDependenciesMeta": {
     "@divvi/cookies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "private": false,
   "devDependencies": {
-    "@react-native-cookies/cookies": "^6.2.1",
+    "@divvi/cookies": "^6.2.3",
     "@types/jest": "^29.5.14",
     "@types/node-fetch": "^2.6.12",
     "@types/tough-cookie": "^4.0.5",
@@ -38,6 +38,7 @@
     "@typescript-eslint/eslint-plugin": "^7.2.0",
     "@valora/eslint-config-typescript": "^0.0.1",
     "@valora/prettier-config": "^0.0.1",
+    "commit-and-tag-version": "^9.6.0",
     "conventional-changelog-conventionalcommits": "^6.1.0",
     "eslint": "^8.57.0",
     "eslint-plugin-import": "^2.29.1",
@@ -49,7 +50,6 @@
     "jest-fetch-mock": "https://github.com/jefflau/jest-fetch-mock#69882ba",
     "prettier": "3.4.2",
     "semantic-release": "^19.0.5",
-    "commit-and-tag-version": "^9.6.0",
     "ts-jest": "^29.2.5",
     "typescript": "^5.7.3"
   },
@@ -57,7 +57,7 @@
     "@react-native-cookies/cookies": "^6.2.1"
   },
   "peerDependenciesMeta": {
-    "@react-native-cookies/cookies": {
+    "@divvi/cookies": {
       "optional": true
     }
   },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "typescript": "^5.7.3"
   },
   "peerDependencies": {
-    "@divvi/cookies": "^6.2.1"
+    "@divvi/cookies": "^6.2.3"
   },
   "peerDependenciesMeta": {
     "@divvi/cookies": {

--- a/src/index-react-native.ts
+++ b/src/index-react-native.ts
@@ -3,7 +3,7 @@ import { FiatConnectClientImpl, createSiweConfig } from './fiat-connect-client'
 import { SiweImpl } from './siwe-client'
 import { FiatConnectClientConfig, SiweClientConfig } from './types'
 export * from './types'
-import CookieManager from '@react-native-cookies/cookies'
+import CookieManager from '@divvi/cookies'
 
 export class FiatConnectClient extends FiatConnectClientImpl {
   constructor(

--- a/test/index-react-native.test.ts
+++ b/test/index-react-native.test.ts
@@ -2,7 +2,7 @@ import { FiatConnectClient, SiweClient } from '../src/index-react-native'
 import { Network } from '@fiatconnect/fiatconnect-types'
 import * as siwe from 'siwe'
 import 'jest-fetch-mock'
-import CookieManager, { Cookies } from '@react-native-cookies/cookies'
+import CookieManager, { Cookies } from '@divvi/cookies'
 import { mockClockResponse } from './mocks'
 
 // work around from
@@ -21,7 +21,7 @@ const mockSetCookies: Cookies = {
   },
 }
 
-jest.mock('@react-native-cookies/cookies', () => {
+jest.mock('@divvi/cookies', () => {
   return {
     get: jest.fn(),
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -317,6 +317,13 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
+"@divvi/cookies@^6.2.3":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@divvi/cookies/-/cookies-6.2.3.tgz#1cf922bcf499bf78ed64d91494967fdf54899336"
+  integrity sha512-XSDEXNy002b9vZ3h+tKMbP82lYOGOPqbnreQh5HeRvXLdGyunvgHNztFuVtSoW2hInIoiXo1dMoBVTfwEhKnzQ==
+  dependencies:
+    invariant "^2.2.4"
+
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
@@ -977,13 +984,6 @@
     "@pnpm/config.env-replace" "^1.1.0"
     "@pnpm/network.ca-file" "^1.0.1"
     config-chain "^1.1.11"
-
-"@react-native-cookies/cookies@^6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@react-native-cookies/cookies/-/cookies-6.2.1.tgz#54d50b9496400bbdc19e43c155f70f8f918999e3"
-  integrity sha512-D17wCA0DXJkGJIxkL74Qs9sZ3sA+c+kCoGmXVknW7bVw/W+Vv1m/7mWTNi9DLBZSRddhzYw8SU0aJapIaM/g5w==
-  dependencies:
-    invariant "^2.2.4"
 
 "@semantic-release/commit-analyzer@^9.0.2":
   version "9.0.2"
@@ -4188,7 +4188,6 @@ jest-environment-node@^29.7.0:
 
 "jest-fetch-mock@https://github.com/jefflau/jest-fetch-mock#69882ba":
   version "3.1.0"
-  uid "69882ba07f72f3f0e10345a28c725d0850e57ef3"
   resolved "https://github.com/jefflau/jest-fetch-mock#69882ba07f72f3f0e10345a28c725d0850e57ef3"
   dependencies:
     cross-fetch "^3.1.8"


### PR DESCRIPTION
### Description

Since [`@react-native-cookies/cookies`](https://github.com/react-native-cookies/cookies) seems to be not supported anymore (last release >2.5 years ago) we created our own fork [`@divvi/cookies`](https://github.com/divvixyz/cookies) to include Apple privacy manifest (the `PrivacyInfo.xcprivacy` file). This file is required for iOS app publication and its inclusion is beneficial for all SDK consumers building a React Native app, like [Valora](https://github.com/valora-inc/wallet).

Patch diff: https://github.com/react-native-cookies/cookies/compare/master...divvixyz:cookies:master

### Test plan

CI

### Related issues

Related to RET-1308